### PR TITLE
Fetch public messages from API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Security
 * Updated dependencies
 
+### Features
+* Added support for reading messages, using `getMessages()` method (#5)
+
 
 ## 1.2.0 - 2019-06-20
 ### Security

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.stklcode.pubtrans</groupId>
     <artifactId>juraclient</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/de/stklcode/pubtrans/ura/model/Message.java
+++ b/src/main/java/de/stklcode/pubtrans/ura/model/Message.java
@@ -1,0 +1,165 @@
+package de.stklcode.pubtrans.ura.model;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Entity for a message.
+ *
+ * @author Stefan Kalscheuer
+ * @since 1.3
+ */
+public class Message implements Model {
+    private static final int MSG_UUID = 7;
+    private static final int MSG_TYPE = 8;
+    private static final int MSG_PRIORITY = 9;
+    private static final int MSG_TEXT = 10;
+    private static final int NUM_OF_FIELDS = 11;
+
+    private final Stop stop;
+    private final String uuid;
+    private final Integer type;
+    private final Integer priority;
+    private final String text;
+
+    /**
+     * Construct Message object from complete set of data.
+     *
+     * @param stopID        Stop ID.
+     * @param stopName      Stop name.
+     * @param stopIndicator Stop Indicator.
+     * @param stopState     Stop state.
+     * @param stopLatitude  Stop geolocation latitude.
+     * @param stopLongitude Stop geolocation latitude.
+     * @param msgUUID       Message UUID.
+     * @param msgType       Message type.
+     * @param msgPriority   Message priority.
+     * @param msgText       Message text.
+     */
+    public Message(final String stopID,
+                   final String stopName,
+                   final String stopIndicator,
+                   final Integer stopState,
+                   final Double stopLatitude,
+                   final Double stopLongitude,
+                   final String msgUUID,
+                   final Integer msgType,
+                   final Integer msgPriority,
+                   final String msgText) {
+        this(new Stop(stopID,
+                        stopName,
+                        stopIndicator,
+                        stopState,
+                        stopLatitude,
+                        stopLongitude),
+                msgUUID,
+                msgType,
+                msgPriority,
+                msgText);
+    }
+
+    /**
+     * Construct Message object from Stop model and set of additional data.
+     *
+     * @param stop        Stop model
+     * @param msgUUID     Message UUID.
+     * @param msgType     Message type.
+     * @param msgPriority Message priority.
+     * @param msgText     Message text.
+     */
+    public Message(final Stop stop,
+                   final String msgUUID,
+                   final Integer msgType,
+                   final Integer msgPriority,
+                   final String msgText) {
+        this.stop = stop;
+        this.uuid = msgUUID;
+        this.type = msgType;
+        this.priority = msgPriority;
+        this.text = msgText;
+    }
+
+    /**
+     * Construct Message object from raw list of attributes parsed from JSON.
+     *
+     * @param raw List of attributes from JSON line
+     * @throws IOException Thrown on invalid line format.
+     */
+    public Message(final List raw) throws IOException {
+        this(raw, null);
+    }
+
+    /**
+     * Construct Message object from raw list of attributes parsed from JSON with explicitly specified version.
+     *
+     * @param raw     List of attributes from JSON line
+     * @param version API version
+     * @throws IOException Thrown on invalid line format.
+     */
+    public Message(final List raw, final String version) throws IOException {
+        if (raw == null || raw.size() < NUM_OF_FIELDS) {
+            throw new IOException("Invalid number of fields");
+        }
+
+        stop = new Stop(raw);
+
+        if (raw.get(MSG_UUID) instanceof String) {
+            uuid = (String) raw.get(MSG_UUID);
+        } else {
+            throw Model.typeErrorString(MSG_UUID, raw.get(MSG_UUID).getClass());
+        }
+
+        if (raw.get(MSG_TYPE) instanceof Integer) {
+            type = (Integer) raw.get(MSG_TYPE);
+        } else {
+            throw Model.typeError(MSG_TYPE, raw.get(MSG_TYPE).getClass(), "Integer");
+        }
+
+        if (raw.get(MSG_PRIORITY) instanceof Integer) {
+            priority = (Integer) raw.get(MSG_PRIORITY);
+        } else {
+            throw Model.typeError(MSG_PRIORITY, raw.get(MSG_PRIORITY).getClass(), "Integer");
+        }
+
+        if (raw.get(MSG_TEXT) instanceof String) {
+            text = (String) raw.get(MSG_TEXT);
+        } else {
+            throw Model.typeErrorString(MSG_TEXT, raw.get(MSG_TEXT).getClass());
+        }
+    }
+
+    /**
+     * @return The affected stop.
+     */
+    public Stop getStop() {
+        return stop;
+    }
+
+    /**
+     * @return Message's unique identifier.
+     */
+    public String getUuid() {
+        return uuid;
+    }
+
+    /**
+     * @return Message type.
+     */
+    public Integer getType() {
+        return type;
+    }
+
+    /**
+     * @return Message priority. Lower value equals higher priority.
+     */
+    public Integer getPriority() {
+        return priority;
+    }
+
+    /**
+     * @return Message text.
+     */
+    public String getText() {
+        return text;
+    }
+}

--- a/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
@@ -16,6 +16,7 @@
 
 package de.stklcode.pubtrans.ura;
 
+import de.stklcode.pubtrans.ura.model.Message;
 import de.stklcode.pubtrans.ura.model.Stop;
 import de.stklcode.pubtrans.ura.model.Trip;
 import net.bytebuddy.ByteBuddy;
@@ -328,6 +329,43 @@ public class UraClientTest {
         assertThat(trips.get(1).getLineID(), is("25"));
         assertThat(trips.get(3).getLineName(), is("35"));
         assertThat(trips.get(5).getStop().getIndicator(), is("H.12"));
+    }
+
+
+    @Test
+    public void getMessages() {
+        // Mock the HTTP call.
+        mockHttpToFile("instant_V1_messages.txt");
+
+        // Get messages without filter and verify some values.
+        List<Message> messages = new UraClient("mocked")
+                .getMessages();
+        assertThat(messages, hasSize(2));
+        assertThat(messages.get(0).getStop().getId(), is("100707"));
+        assertThat(messages.get(0).getUuid(), is("016e1231d4e30014_100707"));
+        assertThat(messages.get(1).getStop().getName(), is("Herzogenr. Rathaus"));
+        assertThat(messages.get(1).getUuid(), is("016e2cc3a3750006_210511"));
+        assertThat(messages.get(0).getType(), is(0));
+        assertThat(messages.get(1).getPriority(), is(0));
+        assertThat(messages.get(0).getText(), is("Sehr geehrte Fahrgäste, wegen Strassenbauarbeiten kann diese Haltestelle nicht von den Bussen der Linien 17, 44 und N2 angefahren werden."));
+        assertThat(messages.get(1).getText(), is("Sehr geehrte Fahrgäste, diese Haltestelle wird vorübergehend von den Linien 47, 147 und N3 nicht angefahren."));
+    }
+
+    @Test
+    public void getMessagesForStop() {
+        // Mock the HTTP call.
+        mockHttpToFile("instant_V2_messages_stop.txt");
+
+        // Get trips for stop ID 100707 (Berensberger Str.) and verify some values.
+        List<Message> messages = new UraClient("mocked")
+                .forStops("100707")
+                .getMessages();
+        assertThat(messages, hasSize(1));
+        assertThat(messages.stream().filter(t -> !t.getStop().getId().equals("100707")).findAny(), is(Optional.empty()));
+        assertThat(messages.get(0).getUuid(), is("016e1231d4e30014_100707"));
+        assertThat(messages.get(0).getType(), is(0));
+        assertThat(messages.get(0).getPriority(), is(3));
+        assertThat(messages.get(0).getText(), is("Sehr geehrte Fahrgäste, wegen Strassenbauarbeiten kann diese Haltestelle nicht von den Bussen der Linien 17, 44 und N2 angefahren werden."));
     }
 
 

--- a/src/test/java/de/stklcode/pubtrans/ura/model/MessageTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/model/MessageTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Unit test for the {@link Message} metamodel.
+ * Unit test for the {@link Message} meta model.
  *
  * @author Stefan Kalscheuer
  */

--- a/src/test/java/de/stklcode/pubtrans/ura/model/MessageTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/model/MessageTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2016-2019 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.pubtrans.ura.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Unit test for the {@link Message} metamodel.
+ *
+ * @author Stefan Kalscheuer
+ */
+public class MessageTest {
+    @Test
+    public void basicConstructorTest() {
+        Message message = new Message("sid",
+                "name",
+                "indicator",
+                1,
+                2.345,
+                6.789,
+                "msg_uuid",
+                1,
+                3,
+                "message text");
+        assertThat(message.getStop().getId(), is("sid"));
+        assertThat(message.getStop().getName(), is("name"));
+        assertThat(message.getStop().getIndicator(), is("indicator"));
+        assertThat(message.getStop().getState(), is(1));
+        assertThat(message.getStop().getLatitude(), is(2.345));
+        assertThat(message.getStop().getLongitude(), is(6.789));
+        assertThat(message.getUuid(), is("msg_uuid"));
+        assertThat(message.getType(), is(1));
+        assertThat(message.getPriority(), is(3));
+        assertThat(message.getText(), is("message text"));
+    }
+
+    @Test
+    public void listConstructorTest() {
+        /* Create valid raw data list */
+        List<Object> raw = new ArrayList<>();
+        raw.add(1);
+        raw.add("stopName");
+        raw.add("stopId");
+        raw.add("stopIndicator");
+        raw.add(9);
+        raw.add(8.765);
+        raw.add(43.21);
+        raw.add("msg_uuid");
+        raw.add(1);
+        raw.add(3);
+        raw.add("message text");
+
+        try {
+            Message message = new Message(raw);
+            assertThat(message.getStop().getId(), is("stopId"));
+            assertThat(message.getStop().getName(), is("stopName"));
+            assertThat(message.getStop().getIndicator(), is("stopIndicator"));
+            assertThat(message.getStop().getState(), is(9));
+            assertThat(message.getStop().getLatitude(), is(8.765));
+            assertThat(message.getStop().getLongitude(), is(43.21));
+            assertThat(message.getUuid(), is("msg_uuid"));
+            assertThat(message.getType(), is(1));
+            assertThat(message.getPriority(), is(3));
+            assertThat(message.getText(), is("message text"));
+        } catch (IOException e) {
+            fail("Creation of Message from valid list failed: " + e.getMessage());
+        }
+
+        /* Excess elements should be ignored */
+        raw.add("foo");
+        try {
+            Message message = new Message(raw);
+            assertThat(message, is(notNullValue()));
+            raw.remove(11);
+        } catch (IOException e) {
+            fail("Creation of Message from valid list failed: " + e.getMessage());
+        }
+
+        /* Test exceptions on invalid data */
+        List<Object> invalid = new ArrayList<>(raw);
+        invalid.remove(7);
+        invalid.add(7, 123L);
+        try {
+            new Message(invalid);
+            fail("Creation of Message with invalid UUID field successful");
+        } catch (Exception e) {
+            assertThat(e, is(instanceOf(IOException.class)));
+        }
+
+        invalid = new ArrayList<>(raw);
+        invalid.remove(8);
+        invalid.add(8, "abc");
+        try {
+            new Message(invalid);
+            fail("Creation of Message with invalid type field successful");
+        } catch (Exception e) {
+            assertThat(e, is(instanceOf(IOException.class)));
+        }
+
+        invalid = new ArrayList<>(raw);
+        invalid.remove(9);
+        invalid.add(9, "xyz");
+        try {
+            new Message(invalid);
+            fail("Creation of Message with invalid priority field successful");
+        } catch (Exception e) {
+            assertThat(e, is(instanceOf(IOException.class)));
+        }
+
+        invalid = new ArrayList<>(raw);
+        invalid.remove(10);
+        invalid.add(10, 1.23);
+        try {
+            new Message(invalid);
+            fail("Creation of Message with invalid text field successful");
+        } catch (Exception e) {
+            assertThat(e, is(instanceOf(IOException.class)));
+        }
+
+        invalid = new ArrayList<>(raw);
+        invalid.remove(10);
+        try {
+            new Message(invalid);
+            fail("Creation of Message with too short list successful");
+        } catch (Exception e) {
+            assertThat(e, is(instanceOf(IOException.class)));
+        }
+    }
+}

--- a/src/test/resources/de/stklcode/pubtrans/ura/instant_V1_messages.txt
+++ b/src/test/resources/de/stklcode/pubtrans/ura/instant_V1_messages.txt
@@ -1,0 +1,3 @@
+[4,"1.0",1572882473479]
+[2,"Berensberger Str.","100707","",0,50.8087069,6.0607177,"016e1231d4e30014_100707",0,3,"Sehr geehrte Fahrgäste, wegen Strassenbauarbeiten kann diese Haltestelle nicht von den Bussen der Linien 17, 44 und N2 angefahren werden."]
+[2,"Herzogenr. Rathaus","210511","",0,50.8718175,6.1025675,"016e2cc3a3750006_210511",0,0,"Sehr geehrte Fahrgäste, diese Haltestelle wird vorübergehend von den Linien 47, 147 und N3 nicht angefahren."]

--- a/src/test/resources/de/stklcode/pubtrans/ura/instant_V2_messages_stop.txt
+++ b/src/test/resources/de/stklcode/pubtrans/ura/instant_V2_messages_stop.txt
@@ -1,0 +1,2 @@
+[4,"2.0",1572882473479]
+[2,"Berensberger Str.","100707","",0,50.8087069,6.0607177,"016e1231d4e30014_100707",0,3,"Sehr geehrte Fahrgäste, wegen Strassenbauarbeiten kann diese Haltestelle nicht von den Bussen der Linien 17, 44 und N2 angefahren werden."]


### PR DESCRIPTION
Resolves #5.

New method `UraClient#getMessages()` is introduced which fetches a list of `de.stklcode.pubtrans.ura.model.Message` entities.

May be combined with stop filter like 
```java
List<Message> msgs = new UraClient("http://ura.example.com")
        .forStops("123", "456")
        .getMessages();
```

