### PR TITLE
introduce custom exception class instead of RuntimeExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Changes
 * Using native Java 11 HTTP client
 * Client configuration with separate `UraClientConfiguration` class and builder
+* Client throws custom checked exception `UraClientException` instead of runtime exceptions on errors (#10)
 
 
 ## 1.3.0 - 2019-12-04

--- a/src/main/java/de/stklcode/pubtrans/ura/exception/UraClientConfigurationException.java
+++ b/src/main/java/de/stklcode/pubtrans/ura/exception/UraClientConfigurationException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016-2020 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.pubtrans.ura.exception;
+
+/**
+ * Custom exception class indicating an error with the URA client configuration.
+ *
+ * @author Stefan Kalscheuer
+ * @since 2.0
+ */
+public class UraClientConfigurationException extends UraClientException {
+    private static final long serialVersionUID = -8035752391477338659L;
+
+    /**
+     * Default constructor.
+     *
+     * @param message The detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause   The cause (which is saved for later retrieval by the {@link #getCause()} method).
+     */
+    public UraClientConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/de/stklcode/pubtrans/ura/exception/UraClientException.java
+++ b/src/main/java/de/stklcode/pubtrans/ura/exception/UraClientException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016-2020 Stefan Kalscheuer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.stklcode.pubtrans.ura.exception;
+
+import java.io.IOException;
+
+/**
+ * Custom exception class indicating an error with the URA API communication.
+ *
+ * @author Stefan Kalscheuer
+ * @since 2.0
+ */
+public class UraClientException extends IOException {
+    private static final long serialVersionUID = 4585240685746203433L;
+
+    /**
+     * Default constructor.
+     *
+     * @param message The detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause   The cause (which is saved for later retrieval by the {@link #getCause()} method).
+     */
+    public UraClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -16,6 +16,7 @@
 
 module de.stklcode.pubtrans.juraclient {
     exports de.stklcode.pubtrans.ura;
+    exports de.stklcode.pubtrans.ura.exception;
     exports de.stklcode.pubtrans.ura.model;
     exports de.stklcode.pubtrans.ura.reader;
 

--- a/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
@@ -19,6 +19,7 @@ package de.stklcode.pubtrans.ura;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import de.stklcode.pubtrans.ura.exception.UraClientException;
 import de.stklcode.pubtrans.ura.model.Message;
 import de.stklcode.pubtrans.ura.model.Stop;
 import de.stklcode.pubtrans.ura.model.Trip;
@@ -63,7 +64,7 @@ public class UraClientTest {
     }
 
     @Test
-    public void getStopsTest() {
+    public void getStopsTest() throws UraClientException {
         // Mock the HTTP call.
         mockHttpToFile(2, "instant_V2_stops.txt");
 
@@ -89,7 +90,7 @@ public class UraClientTest {
     }
 
     @Test
-    public void getStopsForLineTest() {
+    public void getStopsForLineTest() throws UraClientException {
         // Mock the HTTP call.
         mockHttpToFile(2, "instant_V2_stops_line.txt");
 
@@ -107,7 +108,7 @@ public class UraClientTest {
     }
 
     @Test
-    public void getStopsForPositionTest() {
+    public void getStopsForPositionTest() throws UraClientException {
         // Mock the HTTP call.
         mockHttpToFile(1, "instant_V1_stops_circle.txt");
 
@@ -133,7 +134,7 @@ public class UraClientTest {
     }
 
     @Test
-    public void getTripsForDestinationNamesTest() {
+    public void getTripsForDestinationNamesTest() throws UraClientException {
         // Mock the HTTP call.
         mockHttpToFile(1, "instant_V1_trips_destination.txt");
 
@@ -156,7 +157,7 @@ public class UraClientTest {
     }
 
     @Test
-    public void getTripsTowardsTest() {
+    public void getTripsTowardsTest() throws UraClientException {
         // Mock the HTTP call.
         mockHttpToFile(1, "instant_V1_trips_towards.txt");
 
@@ -171,7 +172,7 @@ public class UraClientTest {
     }
 
     @Test
-    public void getTripsTest() {
+    public void getTripsTest() throws UraClientException {
         // Mock the HTTP call.
         mockHttpToFile(1, "instant_V1_trips_all.txt");
 
@@ -224,7 +225,7 @@ public class UraClientTest {
     }
 
     @Test
-    public void getTripsForStopTest() {
+    public void getTripsForStopTest() throws UraClientException {
         // Mock the HTTP call.
         mockHttpToFile(1, "instant_V1_trips_stop.txt");
 
@@ -254,7 +255,7 @@ public class UraClientTest {
     }
 
     @Test
-    public void getTripsForLine() {
+    public void getTripsForLine() throws UraClientException {
         // Mock the HTTP call.
         mockHttpToFile(1, "instant_V1_trips_line.txt");
 
@@ -303,7 +304,7 @@ public class UraClientTest {
     }
 
     @Test
-    public void getTripsForStopAndLine() {
+    public void getTripsForStopAndLine() throws UraClientException {
         // Mock the HTTP call.
         mockHttpToFile(1, "instant_V1_trips_stop_line.txt");
 
@@ -324,7 +325,7 @@ public class UraClientTest {
 
 
     @Test
-    public void getMessages() {
+    public void getMessages() throws UraClientException {
         // Mock the HTTP call.
         mockHttpToFile(1, "instant_V1_messages.txt");
 
@@ -343,7 +344,7 @@ public class UraClientTest {
     }
 
     @Test
-    public void getMessagesForStop() {
+    public void getMessagesForStop() throws UraClientException {
         // Mock the HTTP call.
         mockHttpToFile(2, "instant_V2_messages_stop.txt");
 


### PR DESCRIPTION
We now use a custom, checked exceptions on errors that can occur with the API communication or configuration. instead of throwing an unchecked `IllegalStateException`.