### PR TITLE
remove future from trip reader after closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 * Client configuration with separate `UraClientConfiguration` class and builder
 * Client throws custom checked exception `UraClientException` instead of runtime exceptions on errors (#10)
 
+### Fixed
+* Allow reopening an `AsyncUraTripReader` without raising an exception (#12)
+
 
 ## 1.3.0 - 2019-12-04
 ### Security

--- a/src/main/java/de/stklcode/pubtrans/ura/reader/AsyncUraTripReader.java
+++ b/src/main/java/de/stklcode/pubtrans/ura/reader/AsyncUraTripReader.java
@@ -124,6 +124,8 @@ public class AsyncUraTripReader implements AutoCloseable {
         } catch (TimeoutException e) {
             // Task failed to finish within 1 second.
             future.cancel(true);
+        } finally {
+            future = null;
         }
     }
 


### PR DESCRIPTION
Future was not removed from the reader instance after `close()` has been called, so re-opening was not possible. Remove the instance after termination allows calling `open()` again.