### PR TITLE
[backport] remove future from trip reader after closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## unreleased
+### Fixed
+* Allow reopening an `AsyncUraTripReader` without raising an exception (#13)
+
+
 ## 1.3.0 - 2019-12-04
 ### Security
 * Updated dependencies

--- a/src/main/java/de/stklcode/pubtrans/ura/reader/AsyncUraTripReader.java
+++ b/src/main/java/de/stklcode/pubtrans/ura/reader/AsyncUraTripReader.java
@@ -134,6 +134,8 @@ public class AsyncUraTripReader implements AutoCloseable {
         } catch (TimeoutException e) {
             // Task failed to finish within 1 second.
             future.cancel(true);
+        } finally {
+            future = null;
         }
     }
 

--- a/src/test/java/de/stklcode/pubtrans/ura/reader/AsyncUraTripReaderTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/reader/AsyncUraTripReaderTest.java
@@ -41,6 +41,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -122,7 +124,7 @@ public class AsyncUraTripReaderTest {
 
         tr = new AsyncUraTripReader(
                 new URL(httpMock.baseUrl() + "/interfaces/ura/stream_V2"),
-                Collections.singletonList(trips::add)
+                trips::add
         );
 
         // Open the reader.
@@ -146,6 +148,11 @@ public class AsyncUraTripReaderTest {
         assertThat("Unexpected number of v2 trips after all lines have been flushed", trips.size(), is(7));
         assertThat("Unexpected number of v2 trips in list 2 after all lines have been flushed", trips2.size(), is(5));
         assertThat("Same object should have been pushed to both lists", trips.containsAll(trips2));
+
+        // Opening the reader twice should raise an exception.
+        assertDoesNotThrow(tr::open, "Opening the reader after closing should not fail");
+        assertThrows(IllegalStateException.class, tr::open, "Opening the reader twice should raise an exception");
+        tr.close();
     }
 
     /**


### PR DESCRIPTION
Backport of #12 for v1.x.

Future was not removed from the reader instance after `close()` has been called, so re-opening was not possible. Remove the instance after termination allows calling `open()` again.