### PR TITLE
introduce customizable connect and read timeout

### DIFF
--- a/src/main/java/de/stklcode/pubtrans/ura/UraClient.java
+++ b/src/main/java/de/stklcode/pubtrans/ura/UraClient.java
@@ -475,10 +475,17 @@ public class UraClient implements Serializable {
      */
     private InputStream request(String url) throws IOException {
         try {
-            return HttpClient.newHttpClient().send(
-                    HttpRequest.newBuilder(URI.create(url)).GET().build(),
-                    HttpResponse.BodyHandlers.ofInputStream()
-            ).body();
+            var clientBuilder = HttpClient.newBuilder();
+            if (config.getConnectTimeout() != null) {
+                clientBuilder.connectTimeout(config.getConnectTimeout());
+            }
+
+            var reqBuilder = HttpRequest.newBuilder(URI.create(url)).GET();
+            if (config.getTimeout() != null) {
+                reqBuilder.timeout(config.getTimeout());
+            }
+
+            return clientBuilder.build().send(reqBuilder.build(), HttpResponse.BodyHandlers.ofInputStream()).body();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException("API request interrupted", e);

--- a/src/main/java/de/stklcode/pubtrans/ura/UraClient.java
+++ b/src/main/java/de/stklcode/pubtrans/ura/UraClient.java
@@ -25,9 +25,7 @@ import de.stklcode.pubtrans.ura.model.Trip;
 import de.stklcode.pubtrans.ura.reader.AsyncUraTripReader;
 
 import java.io.*;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -310,6 +308,7 @@ public class UraClient implements Serializable {
         try {
             AsyncUraTripReader reader = new AsyncUraTripReader(
                     URI.create(requestURL(config.getBaseURL() + config.getStreeamPath(), REQUEST_TRIP, query)),
+                    config,
                     consumers
             );
 

--- a/src/main/java/de/stklcode/pubtrans/ura/UraClientConfiguration.java
+++ b/src/main/java/de/stklcode/pubtrans/ura/UraClientConfiguration.java
@@ -1,6 +1,7 @@
 package de.stklcode.pubtrans.ura;
 
 import java.io.Serializable;
+import java.time.Duration;
 
 /**
  * Configurstion Object for the {@link UraClient}.
@@ -17,6 +18,8 @@ public class UraClientConfiguration implements Serializable {
     private final String baseURL;
     private final String instantPath;
     private final String streamPath;
+    private final Duration connectTimeout;
+    private final Duration timeout;
 
     /**
      * Get new configuration {@link Builder} for given base URL.
@@ -38,6 +41,8 @@ public class UraClientConfiguration implements Serializable {
         this.baseURL = builder.baseURL;
         this.instantPath = builder.instantPath;
         this.streamPath = builder.streamPath;
+        this.connectTimeout = builder.connectTimeout;
+        this.timeout = builder.timeout;
     }
 
     /**
@@ -68,12 +73,32 @@ public class UraClientConfiguration implements Serializable {
     }
 
     /**
+     * Get the connection timeout, if any.
+     *
+     * @return Timeout duration or {@code null} if none specified.
+     */
+    public Duration getConnectTimeout() {
+        return this.connectTimeout;
+    }
+
+    /**
+     * Get the response timeout, if any.
+     *
+     * @return Timeout duration or {@code null} if none specified.
+     */
+    public Duration getTimeout() {
+        return this.timeout;
+    }
+
+    /**
      * Builder for {@link UraClientConfiguration} objects.
      */
     public static class Builder {
         private final String baseURL;
         private String instantPath;
         private String streamPath;
+        private Duration connectTimeout;
+        private Duration timeout;
 
         /**
          * Initialize the builder with mandatory base URL.
@@ -85,6 +110,8 @@ public class UraClientConfiguration implements Serializable {
             this.baseURL = baseURL;
             this.instantPath = DEFAULT_INSTANT_PATH;
             this.streamPath = DEFAULT_STREAM_PATH;
+            this.connectTimeout = null;
+            this.timeout = null;
         }
 
         /**
@@ -106,6 +133,28 @@ public class UraClientConfiguration implements Serializable {
          */
         public Builder withStreamPath(String streamPath) {
             this.streamPath = streamPath;
+            return this;
+        }
+
+        /**
+         * Specify a custom connection timeout duration.
+         *
+         * @param connectTimeout Timeout duration.
+         * @return The builder.
+         */
+        public Builder withConnectTimeout(Duration connectTimeout) {
+            this.connectTimeout = connectTimeout;
+            return this;
+        }
+
+        /**
+         * Specify a custom timeout duration.
+         *
+         * @param timeout Timeout duration.
+         * @return The builder.
+         */
+        public Builder withTimeout(Duration timeout) {
+            this.timeout = timeout;
             return this;
         }
 

--- a/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
@@ -393,7 +393,7 @@ public class UraClientTest {
     }
 
     @Test
-    public void timeoutTest() throws IOException {
+    public void timeoutTest() {
         // Try to read trips from TEST-NET-1 IP that is not routed (hopefully) and will not connect within 100ms.
         UraClientException exception = assertThrows(
                 UraClientException.class,
@@ -442,7 +442,6 @@ public class UraClientTest {
                 "Response timeout of 300ms with 100ms delay must not fail"
         );
     }
-
 
     private static void mockHttpToFile(int version, String resourceFile) {
         WireMock.stubFor(


### PR DESCRIPTION
Introduce new timeout configuration in the client configuration object (#9). Both connection and read timeout can be specified.

```java
new UraClient(
    UraClientConfiguration.forBaseURL("https://api.example.com")
                          .withConnectTimeout(Duration.ofSeconde(2))
                          .withTimeout(Duration.ofSeconde(10))
                          .build()
)
```