### PR TITLE
[1.x] allow getTrips() and getMessages() with limit directly from Query instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## unreleased
 
 ### Fixed
-* Querying trips with limit directly from `Query` instance (#19)
+* Querying trips and messages with limit directly from `Query` instance (#19)
 
 
 ## 1.3.2 - 2022-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## unreleased
+
+### Fixed
+* Querying trips with limit directly from `Query` instance (#19)
+
+
 ## 1.3.2 - 2022-08-30
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ List<Stop> stops = ura.forPosition(51.51009, -0.1345734, 200)
 
 ```java
 // Get next 10 trips for given stops and lines in a single direction (all filters optional)
-List<Trip> trips = ura.forStop("100000")
+List<Trip> trips = ura.forStops("100000")
                       .forLines("25", "35")
                       .forDirection(1)
                       .getTrips(10);
 
 // Get trips from given stop towards your destination
-List<Trip> trips = ura.forStopByName("Piccadilly Circus")
+List<Trip> trips = ura.forStopsByName("Piccadilly Circus")
                       .towards("Marble Arch")
                       .getTrips();
 ```
@@ -54,7 +54,7 @@ List<Trip> trips = ura.forStopByName("Piccadilly Circus")
 
 ```java
 // Get next 10 trips for given stops and lines in a single direction (all filters optional)
-List<Message> msgs = ura.forStop("100000")
+List<Message> msgs = ura.forStops("100000")
                         .getMessages();
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.stklcode.pubtrans</groupId>
     <artifactId>juraclient</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/de/stklcode/pubtrans/ura/UraClient.java
+++ b/src/main/java/de/stklcode/pubtrans/ura/UraClient.java
@@ -346,6 +346,18 @@ public class UraClient implements Serializable {
         return getMessages(query, null);
     }
 
+
+    /**
+     * Get list of messages with limit.
+     *
+     * @param limit Maximum number of results.
+     * @return List of trips.
+     * @since 1.3.3
+     */
+    public List<Message> getMessages(final Integer limit) {
+        return getMessages(new Query(), limit);
+    }
+
     /**
      * Get list of messages for given stopIDs with result limit.
      *
@@ -610,6 +622,17 @@ public class UraClient implements Serializable {
          */
         public List<Message> getMessages() {
             return UraClient.this.getMessages(this);
+        }
+
+        /**
+         * Get trips for set filters with limit.
+         *
+         * @param limit Maximum number of results.
+         * @return List of matching messages.
+         * @since 1.3.3
+         */
+        public List<Message> getMessages(final Integer limit) {
+            return UraClient.this.getMessages(this, limit);
         }
     }
 }

--- a/src/main/java/de/stklcode/pubtrans/ura/UraClient.java
+++ b/src/main/java/de/stklcode/pubtrans/ura/UraClient.java
@@ -192,7 +192,7 @@ public class UraClient implements Serializable {
 
     /**
      * Get list of trips.
-     * If forStops() and/or forLines() has been called, those will be used as filter.
+     * If {@link #forStops(String...)} and/or {@link #forLines(String...)} has been called, those will be used as filter.
      *
      * @return List of trips.
      */
@@ -202,7 +202,7 @@ public class UraClient implements Serializable {
 
     /**
      * Get list of trips with limit.
-     * If forStops() and/or forLines() has been called, those will be used as filter.
+     * If {@link #forStops(String...)} and/or {@link #forLines(String...)} has been called, those will be used as filter.
      *
      * @param limit Maximum number of results.
      * @return List of trips.
@@ -564,6 +564,17 @@ public class UraClient implements Serializable {
          */
         public List<Trip> getTrips() {
             return UraClient.this.getTrips(this);
+        }
+
+        /**
+         * Get trips for set filters.
+         *
+         * @param limit Maximum number of results.
+         * @return List of matching trips.
+         * @since 1.3.3
+         */
+        public List<Trip> getTrips(final Integer limit) {
+            return UraClient.this.getTrips(this, limit);
         }
 
         /**

--- a/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
@@ -337,12 +337,13 @@ class UraClientTest {
 
     @Test
     void getMessages() {
+        UraClient uraClient = new UraClient(httpMock.baseUrl());
+
         // Mock the HTTP call.
         mockHttpToFile(1, "instant_V1_messages.txt");
 
         // Get messages without filter and verify some values.
-        List<Message> messages = new UraClient(httpMock.baseUrl())
-                .getMessages();
+        List<Message> messages = uraClient.getMessages();
         assertThat(messages, hasSize(2));
         assertThat(messages.get(0).getStop().getId(), is("100707"));
         assertThat(messages.get(0).getUuid(), is("016e1231d4e30014_100707"));
@@ -352,23 +353,35 @@ class UraClientTest {
         assertThat(messages.get(1).getPriority(), is(0));
         assertThat(messages.get(0).getText(), is("Sehr geehrte Fahrgäste, wegen Strassenbauarbeiten kann diese Haltestelle nicht von den Bussen der Linien 17, 44 und N2 angefahren werden."));
         assertThat(messages.get(1).getText(), is("Sehr geehrte Fahrgäste, diese Haltestelle wird vorübergehend von den Linien 47, 147 und N3 nicht angefahren."));
+
+        // With limit.
+        messages = uraClient.getMessages(1);
+        assertThat(messages, hasSize(1));
+        messages = uraClient.getMessages(3);
+        assertThat(messages, hasSize(2));
     }
 
     @Test
     void getMessagesForStop() {
+        UraClient uraClient = new UraClient(httpMock.baseUrl(), "/interfaces/ura/instant_V2", "/interfaces/ura/stream");
+
         // Mock the HTTP call.
         mockHttpToFile(2, "instant_V2_messages_stop.txt");
 
         // Get trips for stop ID 100707 (Berensberger Str.) and verify some values.
-        List<Message> messages = new UraClient(httpMock.baseUrl(), "/interfaces/ura/instant_V2", "/interfaces/ura/stream")
-                .forStops("100707")
-                .getMessages();
+        List<Message> messages = uraClient.forStops("100707").getMessages();
         assertThat(messages, hasSize(1));
         assertThat(messages.stream().filter(t -> !t.getStop().getId().equals("100707")).findAny(), is(Optional.empty()));
         assertThat(messages.get(0).getUuid(), is("016e1231d4e30014_100707"));
         assertThat(messages.get(0).getType(), is(0));
         assertThat(messages.get(0).getPriority(), is(3));
         assertThat(messages.get(0).getText(), is("Sehr geehrte Fahrgäste, wegen Strassenbauarbeiten kann diese Haltestelle nicht von den Bussen der Linien 17, 44 und N2 angefahren werden."));
+
+        // With limit.
+        messages = uraClient.forStops("100707").getMessages(0);
+        assertThat(messages, hasSize(0));
+        messages = uraClient.forStops("100707").getMessages(2);
+        assertThat(messages, hasSize(1));
     }
 
 

--- a/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
@@ -189,6 +189,12 @@ class UraClientTest {
         assertThat(trips.get(8).getVisitID(), is(30));
         assertThat(trips.get(9).getStop().getId(), is("100002"));
 
+        // With limit.
+        trips = new UraClient(httpMock.baseUrl()).getTrips(5);
+        assertThat(trips, hasSize(5));
+        trips = new UraClient(httpMock.baseUrl()).getTrips(11);
+        assertThat(trips, hasSize(10));
+
         // Repeat test for API V2.
         mockHttpToFile(2, "instant_V2_trips_all.txt");
 
@@ -238,6 +244,12 @@ class UraClientTest {
         assertThat(trips.get(1).getLineID(), is("7"));
         assertThat(trips.get(2).getLineName(), is("25"));
         assertThat(trips.get(3).getStop().getIndicator(), is("H.15"));
+
+        // With limit.
+        trips = new UraClient(httpMock.baseUrl())
+                .forStops("100000")
+                .getTrips(7);
+        assertThat(trips, hasSize(7));
 
         // Get trips for stop name "Uniklinik" and verify some values.
         mockHttpToFile(1, "instant_V1_trips_stop_name.txt");


### PR DESCRIPTION
Backport fixes from #18 into version 1.x