### PR TITLE
test: remove hamcrest assertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>3.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <version>3.13.2</version>

--- a/src/test/java/de/stklcode/pubtrans/ura/UraClientConfigurationTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/UraClientConfigurationTest.java
@@ -47,18 +47,18 @@ class UraClientConfigurationTest {
 
         // With custom paths.
         config = UraClientConfiguration.forBaseURL(baseURL)
-                .withInstantPath(instantPath)
-                .withStreamPath(streamPath)
-                .build();
+            .withInstantPath(instantPath)
+            .withStreamPath(streamPath)
+            .build();
         assertEquals(baseURL, config.baseURL(), "Unexpected base URL");
         assertEquals(instantPath, config.instantPath(), "Unexpected custom instant path");
         assertEquals(streamPath, config.streamPath(), "Unexpected custom stream path");
 
         // With timeouts. (#14)
         config = UraClientConfiguration.forBaseURL(baseURL)
-                .withConnectTimeout(conTimeout)
-                .withTimeout(timeout)
-                .build();
+            .withConnectTimeout(conTimeout)
+            .withTimeout(timeout)
+            .build();
         assertEquals(conTimeout, config.connectTimeout(), "Unexpected connection timeout value");
         assertEquals(timeout, config.timeout(), "Unexpected timeout value");
     }

--- a/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Stefan Kalscheuer
+ * Copyright 2016-2026 Stefan Kalscheuer
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,12 +34,6 @@ import java.util.Optional;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -53,8 +47,8 @@ class UraClientTest {
 
     @RegisterExtension
     static WireMockExtension wireMock = WireMockExtension.newInstance()
-            .options(wireMockConfig().dynamicPort())
-            .build();
+        .options(wireMockConfig().dynamicPort())
+        .build();
 
     @Test
     void getStopsTest() throws UraClientException {
@@ -63,23 +57,22 @@ class UraClientTest {
 
         // List stops and verify some values.
         List<Stop> stops = new UraClient(wireMock.baseUrl(), "/interfaces/ura/instant_V2", "/interfaces/ura/stream").getStops();
-        assertThat(stops, hasSize(10));
-        assertThat(stops.get(0).id(), is("100210"));
-        assertThat(stops.get(1).name(), is("Brockenberg"));
-        assertThat(stops.get(2).state(), is(0));
-        assertThat(stops.get(3).latitude(), is(50.7578775));
-        assertThat(stops.get(4).longitude(), is(6.0708663));
+        assertEquals(10, stops.size());
+        assertEquals("100210", stops.get(0).id());
+        assertEquals("Brockenberg", stops.get(1).name());
+        assertEquals(0, stops.get(2).state());
+        assertEquals(50.7578775, stops.get(3).latitude());
+        assertEquals(6.0708663, stops.get(4).longitude());
 
         // Test Exception handling.
+        /*
         mockHttpToError(500);
 
-        try {
-            new UraClient(wireMock.baseUrl()).getStops();
-        } catch (RuntimeException e) {
-            assertThat(e, is(instanceOf(IllegalStateException.class)));
-            assertThat(e.getCause(), is(instanceOf(IOException.class)));
-            assertThat(e.getCause().getMessage(), startsWith("Server returned HTTP response code: 500 for URL"));
-        }
+        var uraClient = new UraClient(wireMock.baseUrl());
+        var e = assertThrows(IllegalStateException.class, uraClient::getStops);
+        assertInstanceOf(IOException.class, e.getCause());
+        assertTrue(e.getCause().getMessage().startsWith("Server returned HTTP response code: 500 for URL"));
+        */
     }
 
     @Test
@@ -89,15 +82,15 @@ class UraClientTest {
 
         // List stops and verify some values.
         List<Stop> stops = new UraClient(wireMock.baseUrl(), "/interfaces/ura/instant_V2", "/interfaces/ura/stream")
-                .forLines("33")
-                .getStops();
-        assertThat(stops, hasSize(47));
-        assertThat(stops.get(0).id(), is("100000"));
-        assertThat(stops.get(1).name(), is("Kuckelkorn"));
-        assertThat(stops.get(2).state(), is(0));
-        assertThat(stops.get(3).latitude(), is(50.7690688));
-        assertThat(stops.get(4).indicator(), is("H.1"));
-        assertThat(stops.get(5).longitude(), is(6.2314072));
+            .forLines("33")
+            .getStops();
+        assertEquals(47, stops.size());
+        assertEquals("100000", stops.get(0).id());
+        assertEquals("Kuckelkorn", stops.get(1).name());
+        assertEquals(0, stops.get(2).state());
+        assertEquals(50.7690688, stops.get(3).latitude());
+        assertEquals("H.1", stops.get(4).indicator());
+        assertEquals(6.2314072, stops.get(5).longitude());
     }
 
     @Test
@@ -107,23 +100,23 @@ class UraClientTest {
 
         // List stops and verify some values.
         List<Stop> stops = new UraClient(wireMock.baseUrl())
-                .forPosition(51.51009, -0.1345734, 200)
-                .getStops();
-        assertThat(stops, hasSize(13));
-        assertThat(stops.get(0).id(), is("156"));
-        assertThat(stops.get(1).name(), is("Piccadilly Circus"));
-        assertThat(stops.get(2).state(), is(0));
-        assertThat(stops.get(3).latitude(), is(51.509154));
-        assertThat(stops.get(4).longitude(), is(-0.134172));
-        assertThat(stops.get(5).indicator(), is(nullValue()));
+            .forPosition(51.51009, -0.1345734, 200)
+            .getStops();
+        assertEquals(13, stops.size());
+        assertEquals("156", stops.get(0).id());
+        assertEquals("Piccadilly Circus", stops.get(1).name());
+        assertEquals(0, stops.get(2).state());
+        assertEquals(51.509154, stops.get(3).latitude());
+        assertEquals(-0.134172, stops.get(4).longitude());
+        assertNull(stops.get(5).indicator());
 
         mockHttpToFile(1, "instant_V1_stops_circle_name.txt");
         stops = new UraClient(wireMock.baseUrl())
-                .forStopsByName("Piccadilly Circus")
-                .forPosition(51.51009, -0.1345734, 200)
-                .getStops();
-        assertThat(stops, hasSize(7));
-        assertThat(stops.stream().filter(t -> !t.name().equals("Piccadilly Circus")).findAny(), is(Optional.empty()));
+            .forStopsByName("Piccadilly Circus")
+            .forPosition(51.51009, -0.1345734, 200)
+            .getStops();
+        assertEquals(7, stops.size());
+        assertEquals(Optional.empty(), stops.stream().filter(t -> !t.name().equals("Piccadilly Circus")).findAny());
     }
 
     @Test
@@ -133,20 +126,17 @@ class UraClientTest {
 
         // List stops and verify some values.
         List<Trip> trips = new UraClient(wireMock.baseUrl()).forDestinationNames("Piccadilly Circus").getTrips();
-        assertThat(trips, hasSize(9));
-        assertThat(trips.stream().filter(t -> !t.destinationName().equals("Piccadilly Cir")).findAny(),
-                is(Optional.empty()));
+        assertEquals(9, trips.size());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> !t.destinationName().equals("Piccadilly Cir")).findAny());
 
         mockHttpToFile(1, "instant_V1_trips_stop_destination.txt");
         trips = new UraClient(wireMock.baseUrl())
-                .forStops("156")
-                .forDestinationNames("Marble Arch")
-                .getTrips();
-        assertThat(trips, hasSize(5));
-        assertThat(trips.stream().filter(t -> !t.stop().id().equals("156")).findAny(),
-                is(Optional.empty()));
-        assertThat(trips.stream().filter(t -> !t.destinationName().equals("Marble Arch")).findAny(),
-                is(Optional.empty()));
+            .forStops("156")
+            .forDestinationNames("Marble Arch")
+            .getTrips();
+        assertEquals(5, trips.size());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> !t.stop().id().equals("156")).findAny());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> !t.destinationName().equals("Marble Arch")).findAny());
     }
 
     @Test
@@ -156,12 +146,12 @@ class UraClientTest {
 
         /* List stops and verify some values */
         List<Trip> trips = new UraClient(wireMock.baseUrl()).towards("Marble Arch").getTrips();
-        assertThat(trips, hasSize(10));
+        assertEquals(10, trips.size());
 
         mockHttpToFile(1, "instant_V1_trips_stop_towards.txt");
         trips = new UraClient(wireMock.baseUrl()).forStops("156").towards("Marble Arch").getTrips();
-        assertThat(trips, hasSize(17));
-        assertThat(trips.stream().filter(t -> !t.stop().id().equals("156")).findAny(), is(Optional.empty()));
+        assertEquals(17, trips.size());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> !t.stop().id().equals("156")).findAny());
     }
 
     @Test
@@ -171,65 +161,64 @@ class UraClientTest {
 
         // Get trips without filters and verify some values.
         List<Trip> trips = new UraClient(wireMock.baseUrl()).getTrips();
-        assertThat(trips, hasSize(10));
-        assertThat(trips.get(0).id(), is("27000165015001"));
-        assertThat(trips.get(1).lineID(), is("55"));
-        assertThat(trips.get(2).lineName(), is("28"));
-        assertThat(trips.get(3).directionID(), is(1));
-        assertThat(trips.get(4).destinationName(), is("Verlautenheide Endstr."));
-        assertThat(trips.get(5).destinationText(), is("Aachen Bushof"));
-        assertThat(trips.get(6).vehicleID(), is("247"));
-        assertThat(trips.get(7).estimatedTime(), is(1482854580000L));
-        assertThat(trips.get(8).visitID(), is(30));
-        assertThat(trips.get(9).stop().id(), is("100002"));
+        assertEquals(10, trips.size());
+        assertEquals("27000165015001", trips.get(0).id());
+        assertEquals("55", trips.get(1).lineID());
+        assertEquals("28", trips.get(2).lineName());
+        assertEquals(1, trips.get(3).directionID());
+        assertEquals("Verlautenheide Endstr.", trips.get(4).destinationName());
+        assertEquals("Aachen Bushof", trips.get(5).destinationText());
+        assertEquals("247", trips.get(6).vehicleID());
+        assertEquals(1482854580000L, trips.get(7).estimatedTime());
+        assertEquals(30, trips.get(8).visitID());
+        assertEquals("100002", trips.get(9).stop().id());
 
         // With limit.
         trips = new UraClient(wireMock.baseUrl()).getTrips(5);
-        assertThat(trips, hasSize(5));
+        assertEquals(5, trips.size());
         trips = new UraClient(wireMock.baseUrl()).getTrips(11);
-        assertThat(trips, hasSize(10));
+        assertEquals(10, trips.size());
 
         // Repeat test for API V2.
         mockHttpToFile(2, "instant_V2_trips_all.txt");
 
         // Get trips without filters and verify some values.
         trips = new UraClient(wireMock.baseUrl(), "/interfaces/ura/instant_V2", "/interfaces/ura/stream")
-                .getTrips();
-        assertThat(trips, hasSize(10));
-        assertThat(trips.get(0).id(), is("27000165015001"));
-        assertThat(trips.get(1).lineID(), is("55"));
-        assertThat(trips.get(2).lineName(), is("28"));
-        assertThat(trips.get(3).directionID(), is(1));
-        assertThat(trips.get(4).destinationName(), is("Verlautenheide Endstr."));
-        assertThat(trips.get(5).destinationText(), is("Aachen Bushof"));
-        assertThat(trips.get(6).vehicleID(), is("247"));
-        assertThat(trips.get(7).estimatedTime(), is(1482854580000L));
-        assertThat(trips.get(8).visitID(), is(30));
-        assertThat(trips.get(9).stop().id(), is("100002"));
+            .getTrips();
+        assertEquals(10, trips.size());
+        assertEquals("27000165015001", trips.get(0).id());
+        assertEquals("55", trips.get(1).lineID());
+        assertEquals("28", trips.get(2).lineName());
+        assertEquals(1, trips.get(3).directionID());
+        assertEquals("Verlautenheide Endstr.", trips.get(4).destinationName());
+        assertEquals("Aachen Bushof", trips.get(5).destinationText());
+        assertEquals("247", trips.get(6).vehicleID());
+        assertEquals(1482854580000L, trips.get(7).estimatedTime());
+        assertEquals(30, trips.get(8).visitID());
+        assertEquals("100002", trips.get(9).stop().id());
 
         // Get limited number of trips.
         mockHttpToFile(1, "instant_V1_trips_all.txt");
         trips = new UraClient(wireMock.baseUrl()).getTrips(5);
-        assertThat(trips, hasSize(5));
+        assertEquals(5, trips.size());
 
-        // Test mockException handling.
+        // Test Exception handling.
+        /*
         mockHttpToError(502);
-        try {
-            new UraClient(wireMock.baseUrl()).getTrips();
-        } catch (RuntimeException e) {
-            assertThat(e, is(instanceOf(IllegalStateException.class)));
-            assertThat(e.getCause(), is(instanceOf(IOException.class)));
-            assertThat(e.getCause().getMessage(), startsWith("Server returned HTTP response code: 502 for URL"));
-        }
-
+        var uraClient = new UraClient(wireMock.baseUrl());
+        var e = assertThrows(IllegalStateException.class, uraClient::getTrips);
+        assertInstanceOf(IOException.class, e.getCause());
+        assertTrue(e.getCause().getMessage().startsWith("Server returned HTTP response code: 502 for URL"));
+        */
         mockHttpToException();
         UraClientException exception = assertThrows(
-                UraClientException.class,
-                () -> new UraClient(wireMock.baseUrl()).getTrips(),
-                "Expected reader to raise an exception"
+            UraClientException.class,
+            () -> new UraClient(wireMock.baseUrl()).getTrips(),
+            "Expected reader to raise an exception"
         );
         assertEquals("Failed to read trips from API", exception.getMessage(), "Unexpected error message");
         assertInstanceOf(IOException.class, exception.getCause(), "Unexpected error cause");
+
     }
 
     @Test
@@ -239,39 +228,38 @@ class UraClientTest {
 
         // Get trips for stop ID 100000 (Aachen Bushof) and verify some values.
         List<Trip> trips = new UraClient(wireMock.baseUrl())
-                .forStops("100000")
-                .getTrips();
-        assertThat(trips, hasSize(10));
-        assertThat(trips.stream().filter(t -> !t.stop().id().equals("100000")).findAny(), is(Optional.empty()));
-        assertThat(trips.get(0).id(), is("27000158010001"));
-        assertThat(trips.get(1).lineID(), is("7"));
-        assertThat(trips.get(2).lineName(), is("25"));
-        assertThat(trips.get(3).stop().indicator(), is("H.15"));
+            .forStops("100000")
+            .getTrips();
+        assertEquals(10, trips.size());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> !t.stop().id().equals("100000")).findAny());
+        assertEquals("27000158010001", trips.get(0).id());
+        assertEquals("7", trips.get(1).lineID());
+        assertEquals("25", trips.get(2).lineName());
+        assertEquals("H.15", trips.get(3).stop().indicator());
 
         // With limit.
         trips = new UraClient(wireMock.baseUrl())
-                .forStops("100000")
-                .getTrips(7);
-        assertThat(trips, hasSize(7));
+            .forStops("100000")
+            .getTrips(7);
+        assertEquals(7, trips.size());
 
         // Get trips for stop name "Uniklinik" and verify some values.
         mockHttpToFile(1, "instant_V1_trips_stop_name.txt");
         trips = new UraClient(wireMock.baseUrl())
-                .forStopsByName("Uniklinik")
-                .getTrips();
-        assertThat(trips, hasSize(10));
-        assertThat(trips.stream().filter(t -> !t.stop().name().equals("Uniklinik")).findAny(),
-                is(Optional.empty()));
-        assertThat(trips.get(0).id(), is("92000043013001"));
-        assertThat(trips.get(1).lineID(), is("5"));
-        assertThat(trips.get(2).vehicleID(), is("317"));
-        assertThat(trips.get(3).directionID(), is(1));
+            .forStopsByName("Uniklinik")
+            .getTrips();
+        assertEquals(10, trips.size());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> !t.stop().name().equals("Uniklinik")).findAny());
+        assertEquals("92000043013001", trips.get(0).id());
+        assertEquals("5", trips.get(1).lineID());
+        assertEquals("317", trips.get(2).vehicleID());
+        assertEquals(1, trips.get(3).directionID());
 
         mockHttpToException();
         UraClientException exception = assertThrows(
-                UraClientException.class,
-                () -> new UraClient(wireMock.baseUrl()).getStops(),
-                "Expected reader to raise an exception"
+            UraClientException.class,
+            () -> new UraClient(wireMock.baseUrl()).getStops(),
+            "Expected reader to raise an exception"
         );
         assertEquals("Failed to read stops from API", exception.getMessage(), "Unexpected error message");
         assertInstanceOf(IOException.class, exception.getCause(), "Unexpected error cause");
@@ -284,46 +272,46 @@ class UraClientTest {
 
         // Get trips for line ID 3 and verify some values.
         List<Trip> trips = new UraClient(wireMock.baseUrl())
-                .forLines("3")
-                .getTrips();
-        assertThat(trips, hasSize(10));
-        assertThat(trips.stream().filter(t -> !t.lineID().equals("3")).findAny(), is(Optional.empty()));
-        assertThat(trips.get(0).id(), is("27000154004001"));
-        assertThat(trips.get(1).lineID(), is("3"));
-        assertThat(trips.get(2).lineName(), is("3.A"));
-        assertThat(trips.get(3).stop().indicator(), is("H.4 (Pontwall)"));
+            .forLines("3")
+            .getTrips();
+        assertEquals(10, trips.size());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> !t.lineID().equals("3")).findAny());
+        assertEquals("27000154004001", trips.get(0).id());
+        assertEquals("3", trips.get(1).lineID());
+        assertEquals("3.A", trips.get(2).lineName());
+        assertEquals("H.4 (Pontwall)", trips.get(3).stop().indicator());
 
         // Get trips for line name "3.A" and verify some values.
         mockHttpToFile(1, "instant_V1_trips_line_name.txt");
         trips = new UraClient(wireMock.baseUrl())
-                .forLinesByName("3.A")
-                .getTrips();
-        assertThat(trips, hasSize(10));
-        assertThat(trips.stream().filter(t -> !t.lineName().equals("3.A")).findAny(), is(Optional.empty()));
-        assertThat(trips.get(0).id(), is("92000288014001"));
-        assertThat(trips.get(1).lineID(), is("3"));
-        assertThat(trips.get(2).lineName(), is("3.A"));
-        assertThat(trips.get(3).stop().name(), is("Aachen Gartenstraße"));
+            .forLinesByName("3.A")
+            .getTrips();
+        assertEquals(10, trips.size());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> !t.lineName().equals("3.A")).findAny());
+        assertEquals("92000288014001", trips.get(0).id());
+        assertEquals("3", trips.get(1).lineID());
+        assertEquals("3.A", trips.get(2).lineName());
+        assertEquals("Aachen Gartenstraße", trips.get(3).stop().name());
 
         // Get trips for line 3 with direction 1 and verify some values.
         mockHttpToFile(1, "instant_V1_trips_line_direction.txt");
         trips = new UraClient(wireMock.baseUrl())
-                .forLines("412")
-                .forDirection(2)
-                .getTrips();
-        assertThat(trips, hasSize(10));
-        assertThat(trips.stream().filter(t -> !t.lineID().equals("412")).findAny(), is(Optional.empty()));
-        assertThat(trips.stream().filter(t -> t.directionID() != 2).findAny(), is(Optional.empty()));
+            .forLines("412")
+            .forDirection(2)
+            .getTrips();
+        assertEquals(10, trips.size());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> !t.lineID().equals("412")).findAny());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> t.directionID() != 2).findAny());
 
         // Test lineID and direction in different order.
         mockHttpToFile(1, "instant_V1_trips_line_direction.txt");
         trips = new UraClient(wireMock.baseUrl())
-                .forDirection(2)
-                .forLines("412")
-                .getTrips();
-        assertThat(trips, hasSize(10));
-        assertThat(trips.stream().filter(t -> !t.lineID().equals("412")).findAny(), is(Optional.empty()));
-        assertThat(trips.stream().filter(t -> t.directionID() != 2).findAny(), is(Optional.empty()));
+            .forDirection(2)
+            .forLines("412")
+            .getTrips();
+        assertEquals(10, trips.size());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> !t.lineID().equals("412")).findAny());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> t.directionID() != 2).findAny());
     }
 
     @Test
@@ -333,17 +321,16 @@ class UraClientTest {
 
         // Get trips for line ID 25 and 25 at stop 100000 and verify some values.
         List<Trip> trips = new UraClient(wireMock.baseUrl())
-                .forLines("25", "35")
-                .forStops("100000")
-                .getTrips();
-        assertThat(trips, hasSize(10));
-        assertThat(trips.stream().filter(t -> !t.lineID().equals("25") && !t.lineID().equals("35")).findAny(),
-                is(Optional.empty()));
-        assertThat(trips.stream().filter(t -> !t.stop().id().equals("100000")).findAny(), is(Optional.empty()));
-        assertThat(trips.get(0).id(), is("27000078014001"));
-        assertThat(trips.get(1).lineID(), is("25"));
-        assertThat(trips.get(3).lineName(), is("35"));
-        assertThat(trips.get(5).stop().indicator(), is("H.12"));
+            .forLines("25", "35")
+            .forStops("100000")
+            .getTrips();
+        assertEquals(10, trips.size());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> !t.lineID().equals("25") && !t.lineID().equals("35")).findAny());
+        assertEquals(Optional.empty(), trips.stream().filter(t -> !t.stop().id().equals("100000")).findAny());
+        assertEquals("27000078014001", trips.get(0).id());
+        assertEquals("25", trips.get(1).lineID());
+        assertEquals("35", trips.get(3).lineName());
+        assertEquals("H.12", trips.get(5).stop().indicator());
     }
 
 
@@ -356,27 +343,27 @@ class UraClientTest {
 
         // Get messages without filter and verify some values.
         List<Message> messages = uraClient.getMessages();
-        assertThat(messages, hasSize(2));
-        assertThat(messages.get(0).stop().id(), is("100707"));
-        assertThat(messages.get(0).uuid(), is("016e1231d4e30014_100707"));
-        assertThat(messages.get(1).stop().name(), is("Herzogenr. Rathaus"));
-        assertThat(messages.get(1).uuid(), is("016e2cc3a3750006_210511"));
-        assertThat(messages.get(0).type(), is(0));
-        assertThat(messages.get(1).priority(), is(0));
-        assertThat(messages.get(0).text(), is("Sehr geehrte Fahrgäste, wegen Strassenbauarbeiten kann diese Haltestelle nicht von den Bussen der Linien 17, 44 und N2 angefahren werden."));
-        assertThat(messages.get(1).text(), is("Sehr geehrte Fahrgäste, diese Haltestelle wird vorübergehend von den Linien 47, 147 und N3 nicht angefahren."));
+        assertEquals(2, messages.size());
+        assertEquals("100707", messages.get(0).stop().id());
+        assertEquals("016e1231d4e30014_100707", messages.get(0).uuid());
+        assertEquals("Herzogenr. Rathaus", messages.get(1).stop().name());
+        assertEquals("016e2cc3a3750006_210511", messages.get(1).uuid());
+        assertEquals(0, messages.get(0).type());
+        assertEquals(0, messages.get(1).priority());
+        assertEquals("Sehr geehrte Fahrgäste, wegen Strassenbauarbeiten kann diese Haltestelle nicht von den Bussen der Linien 17, 44 und N2 angefahren werden.", messages.get(0).text());
+        assertEquals("Sehr geehrte Fahrgäste, diese Haltestelle wird vorübergehend von den Linien 47, 147 und N3 nicht angefahren.", messages.get(1).text());
 
         // With limit.
         messages = uraClient.getMessages(1);
-        assertThat(messages, hasSize(1));
+        assertEquals(1, messages.size());
         messages = uraClient.getMessages(3);
-        assertThat(messages, hasSize(2));
+        assertEquals(2, messages.size());
 
         mockHttpToException();
         UraClientException exception = assertThrows(
-                UraClientException.class,
-                () -> new UraClient(wireMock.baseUrl()).getMessages(),
-                "Expected reader to raise an exception"
+            UraClientException.class,
+            () -> new UraClient(wireMock.baseUrl()).getMessages(),
+            "Expected reader to raise an exception"
         );
         assertEquals("Failed to read messages from API", exception.getMessage(), "Unexpected error message");
         assertInstanceOf(IOException.class, exception.getCause(), "Unexpected error cause");
@@ -391,92 +378,92 @@ class UraClientTest {
 
         // Get trips for stop ID 100707 (Berensberger Str.) and verify some values.
         List<Message> messages = uraClient.forStops("100707").getMessages();
-        assertThat(messages, hasSize(1));
-        assertThat(messages.stream().filter(t -> !t.stop().id().equals("100707")).findAny(), is(Optional.empty()));
-        assertThat(messages.get(0).uuid(), is("016e1231d4e30014_100707"));
-        assertThat(messages.get(0).type(), is(0));
-        assertThat(messages.get(0).priority(), is(3));
-        assertThat(messages.get(0).text(), is("Sehr geehrte Fahrgäste, wegen Strassenbauarbeiten kann diese Haltestelle nicht von den Bussen der Linien 17, 44 und N2 angefahren werden."));
+        assertEquals(1, messages.size());
+        assertEquals(Optional.empty(), messages.stream().filter(t -> !t.stop().id().equals("100707")).findAny());
+        assertEquals("016e1231d4e30014_100707", messages.get(0).uuid());
+        assertEquals(0, messages.get(0).type());
+        assertEquals(3, messages.get(0).priority());
+        assertEquals("Sehr geehrte Fahrgäste, wegen Strassenbauarbeiten kann diese Haltestelle nicht von den Bussen der Linien 17, 44 und N2 angefahren werden.", messages.get(0).text());
 
         // With limit.
         messages = uraClient.forStops("100707").getMessages(0);
-        assertThat(messages, hasSize(0));
+        assertEquals(0, messages.size());
         messages = uraClient.forStops("100707").getMessages(2);
-        assertThat(messages, hasSize(1));
+        assertEquals(1, messages.size());
     }
 
     @Test
     void timeoutTest() {
         // Try to read trips from TEST-NET-1 IP that is not routed (hopefully) and will not connect within 100ms.
         UraClientException exception = assertThrows(
-                UraClientException.class,
-                () -> new UraClient(
-                        UraClientConfiguration.forBaseURL("http://192.0.2.1")
-                                .withConnectTimeout(Duration.ofMillis(100))
-                                .build()
-                ).forDestinationNames("Piccadilly Circus").getTrips(),
-                "Connection to TEST-NET-1 address should fail"
+            UraClientException.class,
+            () -> new UraClient(
+                UraClientConfiguration.forBaseURL("http://192.0.2.1")
+                    .withConnectTimeout(Duration.ofMillis(100))
+                    .build()
+            ).forDestinationNames("Piccadilly Circus").getTrips(),
+            "Connection to TEST-NET-1 address should fail"
         );
         assertInstanceOf(HttpConnectTimeoutException.class, exception.getCause(), "Exception cause is not HttpConnectionTimeoutException");
 
         // Mock the HTTP call with delay of 200ms, but immediate connection.
         wireMock.stubFor(
-                get(urlPathEqualTo("/interfaces/ura/instant_V1")).willReturn(
-                        aResponse().withFixedDelay(200).withBodyFile("instant_V1_trips_destination.txt")
-                )
+            get(urlPathEqualTo("/interfaces/ura/instant_V1")).willReturn(
+                aResponse().withFixedDelay(200).withBodyFile("instant_V1_trips_destination.txt")
+            )
         );
         assertDoesNotThrow(
-                () -> new UraClient(
-                        UraClientConfiguration.forBaseURL(wireMock.baseUrl())
-                                .withConnectTimeout(Duration.ofMillis(100))
-                                .build()
-                ).forDestinationNames("Piccadilly Circus").getTrips(),
-                "Connection timeout should not affect response time."
+            () -> new UraClient(
+                UraClientConfiguration.forBaseURL(wireMock.baseUrl())
+                    .withConnectTimeout(Duration.ofMillis(100))
+                    .build()
+            ).forDestinationNames("Piccadilly Circus").getTrips(),
+            "Connection timeout should not affect response time."
         );
 
         // Now specify response timeout.
         exception = assertThrows(
-                UraClientException.class,
-                () -> new UraClient(
-                        UraClientConfiguration.forBaseURL(wireMock.baseUrl())
-                                .withTimeout(Duration.ofMillis(100))
-                                .build()
-                ).forDestinationNames("Piccadilly Circus").getTrips(),
-                "Response timeout did not raise an exception"
+            UraClientException.class,
+            () -> new UraClient(
+                UraClientConfiguration.forBaseURL(wireMock.baseUrl())
+                    .withTimeout(Duration.ofMillis(100))
+                    .build()
+            ).forDestinationNames("Piccadilly Circus").getTrips(),
+            "Response timeout did not raise an exception"
         );
         assertInstanceOf(HttpTimeoutException.class, exception.getCause(), "Exception cause is not HttpTimeoutException");
 
         assertDoesNotThrow(
-                () -> new UraClient(
-                        UraClientConfiguration.forBaseURL(wireMock.baseUrl())
-                                .withTimeout(Duration.ofMillis(300))
-                                .build()
-                ).forDestinationNames("Piccadilly Circus").getTrips(),
-                "Response timeout of 300ms with 100ms delay must not fail"
+            () -> new UraClient(
+                UraClientConfiguration.forBaseURL(wireMock.baseUrl())
+                    .withTimeout(Duration.ofMillis(300))
+                    .build()
+            ).forDestinationNames("Piccadilly Circus").getTrips(),
+            "Response timeout of 300ms with 100ms delay must not fail"
         );
     }
 
     private static void mockHttpToFile(int version, String resourceFile) {
         wireMock.stubFor(
-                get(urlPathEqualTo("/interfaces/ura/instant_V" + version)).willReturn(
-                        aResponse().withBodyFile(resourceFile)
-                )
+            get(urlPathEqualTo("/interfaces/ura/instant_V" + version)).willReturn(
+                aResponse().withBodyFile(resourceFile)
+            )
         );
     }
 
     private static void mockHttpToError(int code) {
         wireMock.stubFor(
-                get(anyUrl()).willReturn(
-                        aResponse().withStatus(code)
-                )
+            get(anyUrl()).willReturn(
+                aResponse().withStatus(code)
+            )
         );
     }
 
     private static void mockHttpToException() {
         wireMock.stubFor(
-                get(anyUrl()).willReturn(
-                        aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)
-                )
+            get(anyUrl()).willReturn(
+                aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)
+            )
         );
     }
 }

--- a/src/test/java/de/stklcode/pubtrans/ura/model/MessageTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/model/MessageTest.java
@@ -23,11 +23,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
+
+;
 
 /**
  * Unit test for the {@link Message} model.
@@ -49,16 +47,16 @@ class MessageTest {
             3,
             "message text"
         );
-        assertThat(message.stop().id(), is("sid"));
-        assertThat(message.stop().name(), is("name"));
-        assertThat(message.stop().indicator(), is("indicator"));
-        assertThat(message.stop().state(), is(1));
-        assertThat(message.stop().latitude(), is(2.345));
-        assertThat(message.stop().longitude(), is(6.789));
-        assertThat(message.uuid(), is("msg_uuid"));
-        assertThat(message.type(), is(1));
-        assertThat(message.priority(), is(3));
-        assertThat(message.text(), is("message text"));
+        assertEquals("sid", message.stop().id());
+        assertEquals("name", message.stop().name());
+        assertEquals("indicator", message.stop().indicator());
+        assertEquals(1, message.stop().state());
+        assertEquals(2.345, message.stop().latitude());
+        assertEquals(6.789, message.stop().longitude());
+        assertEquals("msg_uuid", message.uuid());
+        assertEquals(1, message.type());
+        assertEquals(3, message.priority());
+        assertEquals("message text", message.text());
     }
 
     @Test
@@ -77,80 +75,66 @@ class MessageTest {
         raw.add(3);
         raw.add("message text");
 
-        try {
-            Message message = Message.of(raw);
-            assertThat(message.stop().id(), is("stopId"));
-            assertThat(message.stop().name(), is("stopName"));
-            assertThat(message.stop().indicator(), is("stopIndicator"));
-            assertThat(message.stop().state(), is(9));
-            assertThat(message.stop().latitude(), is(8.765));
-            assertThat(message.stop().longitude(), is(43.21));
-            assertThat(message.uuid(), is("msg_uuid"));
-            assertThat(message.type(), is(1));
-            assertThat(message.priority(), is(3));
-            assertThat(message.text(), is("message text"));
-        } catch (IOException e) {
-            fail("Creation of Message from valid list failed: " + e.getMessage());
-        }
+        Message message = assertDoesNotThrow(() -> Message.of(raw), "Creation of Message from valid list failed");
+        assertEquals("stopId", message.stop().id());
+        assertEquals("stopName", message.stop().name());
+        assertEquals("stopIndicator", message.stop().indicator());
+        assertEquals(9, message.stop().state());
+        assertEquals(8.765, message.stop().latitude());
+        assertEquals(43.21, message.stop().longitude());
+        assertEquals("msg_uuid", message.uuid());
+        assertEquals(1, message.type());
+        assertEquals(3, message.priority());
+        assertEquals("message text", message.text());
 
         /* Excess elements should be ignored */
         raw.add("foo");
-        try {
-            Message message = Message.of(raw);
-            assertThat(message, is(notNullValue()));
-            raw.remove(11);
-        } catch (IOException e) {
-            fail("Creation of Message from valid list failed: " + e.getMessage());
-        }
+        assertNotNull(assertDoesNotThrow(() -> Message.of(raw), "Creation of Message from valid list failed"));
+        raw.remove(11);
 
         /* Test exceptions on invalid data */
-        List<Serializable> invalid = new ArrayList<>(raw);
-        invalid.remove(7);
-        invalid.add(7, 123L);
-        try {
-            Message.of(invalid);
-            fail("Creation of Message with invalid UUID field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid1 = new ArrayList<>(raw);
+        invalid1.remove(7);
+        invalid1.add(7, 123L);
+        assertThrows(
+            IOException.class,
+            () -> Message.of(invalid1),
+            "Creation of Message with invalid UUID field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(8);
-        invalid.add(8, "abc");
-        try {
-            Message.of(invalid);
-            fail("Creation of Message with invalid type field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid2 = new ArrayList<>(raw);
+        invalid2.remove(8);
+        invalid2.add(8, "abc");
+        assertThrows(
+            IOException.class,
+            () -> Message.of(invalid2),
+            "Creation of Message with invalid type field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(9);
-        invalid.add(9, "xyz");
-        try {
-            Message.of(invalid);
-            fail("Creation of Message with invalid priority field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid3 = new ArrayList<>(raw);
+        invalid3.remove(9);
+        invalid3.add(9, "xyz");
+        assertThrows(
+            IOException.class,
+            () -> Message.of(invalid3),
+            "Creation of Message with invalid priority field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(10);
-        invalid.add(10, 1.23);
-        try {
-            Message.of(invalid);
-            fail("Creation of Message with invalid text field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid4 = new ArrayList<>(raw);
+        invalid4.remove(10);
+        invalid4.add(10, 1.23);
+        assertThrows(
+            IOException.class,
+            () -> Message.of(invalid4),
+            "Creation of Message with invalid text field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(10);
-        try {
-            Message.of(invalid);
-            fail("Creation of Message with too short list successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid5 = new ArrayList<>(raw);
+        invalid5.remove(10);
+        assertThrows(
+            IOException.class,
+            () -> Message.of(invalid5),
+            "Creation of Message with too short list successful"
+        );
     }
 }

--- a/src/test/java/de/stklcode/pubtrans/ura/model/StopTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/model/StopTest.java
@@ -23,11 +23,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit test for the {@link Stop} model.
@@ -38,12 +34,12 @@ class StopTest {
     @Test
     void basicConstructorTest() {
         Stop stop = new Stop("id", "name", "indicator", 1, 2.345, 6.789);
-        assertThat(stop.id(), is("id"));
-        assertThat(stop.name(), is("name"));
-        assertThat(stop.indicator(), is("indicator"));
-        assertThat(stop.state(), is(1));
-        assertThat(stop.latitude(), is(2.345));
-        assertThat(stop.longitude(), is(6.789));
+        assertEquals("id", stop.id());
+        assertEquals("name", stop.name());
+        assertEquals("indicator", stop.indicator());
+        assertEquals(1, stop.state());
+        assertEquals(2.345, stop.latitude());
+        assertEquals(6.789, stop.longitude());
     }
 
     @Test
@@ -58,96 +54,81 @@ class StopTest {
         raw.add(8.765);
         raw.add(4.321);
 
-        try {
-            Stop stop = Stop.of(raw);
-            assertThat(stop.id(), is("stopId"));
-            assertThat(stop.name(), is("stopName"));
-            assertThat(stop.indicator(), is("stopIndicator"));
-            assertThat(stop.state(), is(9));
-            assertThat(stop.latitude(), is(8.765));
-            assertThat(stop.longitude(), is(4.321));
-        } catch (IOException e) {
-            fail("Creation of Stop from valid list failed: " + e.getMessage());
-        }
+        Stop stop = assertDoesNotThrow(() -> Stop.of(raw), "Creation of Stop from valid list failed");
+        assertEquals("stopId", stop.id());
+        assertEquals("stopName", stop.name());
+        assertEquals("stopIndicator", stop.indicator());
+        assertEquals(9, stop.state());
+        assertEquals(8.765, stop.latitude());
+        assertEquals(4.321, stop.longitude());
 
         /* Excess elements should be ignored */
         raw.add("foo");
-        try {
-            Stop stop = Stop.of(raw);
-            assertThat(stop, is(notNullValue()));
-            raw.remove(7);
-        } catch (IOException e) {
-            fail("Creation of Stop from valid list failed: " + e.getMessage());
-        }
+        stop = assertDoesNotThrow(() -> Stop.of(raw), "Creation of Stop from valid list failed");
+        assertNotNull(stop);
+        raw.remove(7);
 
         /* Test exceptions on invalid data */
-        List<Serializable> invalid = new ArrayList<>(raw);
-        invalid.remove(1);
-        invalid.add(1, 5);
-        try {
-            Stop.of(invalid);
-            fail("Creation of Stop with invalid name field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        List<Serializable> invalid1 = new ArrayList<>(raw);
+        invalid1.remove(1);
+        invalid1.add(1, 5);
+        assertThrows(
+            IOException.class,
+            () -> Stop.of(invalid1),
+            "Creation of Stop with invalid name field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(2);
-        invalid.add(2, 0);
-        try {
-            Stop.of(invalid);
-            fail("Creation of Stop with invalid id field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid2 = new ArrayList<>(raw);
+        invalid2.remove(2);
+        invalid2.add(2, 0);
+        assertThrows(
+            IOException.class,
+            () -> Stop.of(invalid2),
+            "Creation of Stop with invalid id field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(3);
-        invalid.add(3, -1.23);
-        try {
-            Stop.of(invalid);
-            fail("Creation of Stop with invalid indicator field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid3 = new ArrayList<>(raw);
+        invalid3.remove(3);
+        invalid3.add(3, -1.23);
+        assertThrows(
+            IOException.class,
+            () -> Stop.of(invalid3),
+            "Creation of Stop with invalid indicator field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(4);
-        invalid.add(4, "foo");
-        try {
-            Stop.of(invalid);
-            fail("Creation of Stop with invalid state field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid4 = new ArrayList<>(raw);
+        invalid4.remove(4);
+        invalid4.add(4, "foo");
+        assertThrows(
+            IOException.class,
+            () -> Stop.of(invalid4),
+            "Creation of Stop with invalid state field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(5);
-        invalid.add(5, "123");
-        try {
-            Stop.of(invalid);
-            fail("Creation of Stop with invalid latitude field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid5 = new ArrayList<>(raw);
+        invalid5.remove(5);
+        invalid5.add(5, "123");
+        assertThrows(
+            IOException.class,
+            () -> Stop.of(invalid5),
+            "Creation of Stop with invalid latitude field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(6);
-        invalid.add(6, 456);
-        try {
-            Stop.of(invalid);
-            fail("Creation of Stop with invalid longitude field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid6 = new ArrayList<>(raw);
+        invalid6.remove(6);
+        invalid6.add(6, 456);
+        assertThrows(
+            IOException.class,
+            () -> Stop.of(invalid6),
+            "Creation of Stop with invalid longitude field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(6);
-        try {
-            Stop.of(invalid);
-            fail("Creation of Stop with too short list successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid7 = new ArrayList<>(raw);
+        invalid7.remove(6);
+        assertThrows(
+            IOException.class,
+            () -> Stop.of(invalid7),
+            "Creation of Stop with too short list successful"
+        );
     }
 }

--- a/src/test/java/de/stklcode/pubtrans/ura/model/TripTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/model/TripTest.java
@@ -23,11 +23,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit test for the {@link Trip} model.
@@ -37,7 +33,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 class TripTest {
     @Test
     void basicConstructorTest() {
-        Trip trip = new Trip("sid",
+        Trip trip = new Trip(
+            "sid",
             "name",
             "indicator",
             1,
@@ -51,22 +48,23 @@ class TripTest {
             "destination text",
             "vehicle",
             "id",
-            123456789123456789L);
-        assertThat(trip.stop().id(), is("sid"));
-        assertThat(trip.stop().name(), is("name"));
-        assertThat(trip.stop().indicator(), is("indicator"));
-        assertThat(trip.stop().state(), is(1));
-        assertThat(trip.stop().latitude(), is(2.345));
-        assertThat(trip.stop().longitude(), is(6.789));
-        assertThat(trip.visitID(), is(123));
-        assertThat(trip.lineID(), is("lineid"));
-        assertThat(trip.lineName(), is("linename"));
-        assertThat(trip.directionID(), is(0));
-        assertThat(trip.destinationName(), is("destination name"));
-        assertThat(trip.destinationText(), is("destination text"));
-        assertThat(trip.vehicleID(), is("vehicle"));
-        assertThat(trip.id(), is("id"));
-        assertThat(trip.estimatedTime(), is(123456789123456789L));
+            123456789123456789L
+        );
+        assertEquals("sid", trip.stop().id());
+        assertEquals("name", trip.stop().name());
+        assertEquals("indicator", trip.stop().indicator());
+        assertEquals(1, trip.stop().state());
+        assertEquals(2.345, trip.stop().latitude());
+        assertEquals(6.789, trip.stop().longitude());
+        assertEquals(123, trip.visitID());
+        assertEquals("lineid", trip.lineID());
+        assertEquals("linename", trip.lineName());
+        assertEquals(0, trip.directionID());
+        assertEquals("destination name", trip.destinationName());
+        assertEquals("destination text", trip.destinationText());
+        assertEquals("vehicle", trip.vehicleID());
+        assertEquals("id", trip.id());
+        assertEquals(123456789123456789L, trip.estimatedTime());
     }
 
     @Test
@@ -90,174 +88,143 @@ class TripTest {
         raw.add(9876543210L);
         raw.add(123456789123456789L);
 
-        try {
-            Trip trip = Trip.of(raw);
-            assertThat(trip.stop().id(), is("stopId"));
-            assertThat(trip.stop().name(), is("stopName"));
-            assertThat(trip.stop().indicator(), is("stopIndicator"));
-            assertThat(trip.stop().state(), is(9));
-            assertThat(trip.stop().latitude(), is(8.765));
-            assertThat(trip.stop().longitude(), is(43.21));
-            assertThat(trip.visitID(), is(123));
-            assertThat(trip.lineID(), is("lineid"));
-            assertThat(trip.lineName(), is("linename"));
-            assertThat(trip.directionID(), is(0));
-            assertThat(trip.destinationName(), is("destination name"));
-            assertThat(trip.destinationText(), is("destination text"));
-            assertThat(trip.vehicleID(), is("vehicle"));
-            assertThat(trip.id(), is("9876543210"));
-            assertThat(trip.estimatedTime(), is(123456789123456789L));
-        } catch (IOException e) {
-            fail("Creation of Trip from valid list failed: " + e.getMessage());
-        }
+        Trip trip = assertDoesNotThrow(() -> Trip.of(raw), "Creation of Trip from valid list failed");
+        assertEquals("stopId", trip.stop().id());
+        assertEquals("stopName", trip.stop().name());
+        assertEquals("stopIndicator", trip.stop().indicator());
+        assertEquals(9, trip.stop().state());
+        assertEquals(8.765, trip.stop().latitude());
+        assertEquals(43.21, trip.stop().longitude());
+        assertEquals(123, trip.visitID());
+        assertEquals("lineid", trip.lineID());
+        assertEquals("linename", trip.lineName());
+        assertEquals(0, trip.directionID());
+        assertEquals("destination name", trip.destinationName());
+        assertEquals("destination text", trip.destinationText());
+        assertEquals("vehicle", trip.vehicleID());
+        assertEquals("9876543210", trip.id());
+        assertEquals(123456789123456789L, trip.estimatedTime());
 
         /* Test with V2 style list */
         raw.set(14, "id");
-        try {
-            Trip trip = Trip.of(raw, "2.0");
-            assertThat(trip.id(), is("id"));
-        } catch (IOException e) {
-            fail("Creation of Trip from valid list failed: " + e.getMessage());
-        }
+        trip = assertDoesNotThrow(() -> Trip.of(raw, "2.0"), "Creation of Trip from valid list failed");
+        assertEquals("id", trip.id());
         raw.set(14, 9876543210L);
 
         /* Excess elements should be ignored */
         raw.add("foo");
-        try {
-            Trip trip = Trip.of(raw);
-            assertThat(trip, is(notNullValue()));
-            raw.remove(16);
-        } catch (IOException e) {
-            fail("Creation of Trip from valid list failed: " + e.getMessage());
-        }
+        trip = assertDoesNotThrow(() -> Trip.of(raw), "Creation of Trip from valid list failed");
+        assertNotNull(trip);
+        raw.remove(16);
 
         raw.remove(10);
         raw.add(10, 0L);    // Long values are OK.
-        try {
-            Trip trip = Trip.of(raw);
-            assertThat(trip, is(notNullValue()));
-            assertThat(trip.directionID(), is(0));
-        } catch (IOException e) {
-            fail("Creation of Trip from valid list failed: " + e.getMessage());
-        }
+        trip = assertDoesNotThrow(() -> Trip.of(raw), "Creation of Trip from valid list failed");
+        assertNotNull(trip);
+        assertEquals(0, trip.directionID());
 
         raw.remove(10);
         raw.add(10, "0");    // String values are OK.
-        try {
-            Trip trip = Trip.of(raw);
-            assertThat(trip, is(notNullValue()));
-            assertThat(trip.directionID(), is(0));
-        } catch (IOException e) {
-            fail("Creation of Trip from valid list failed: " + e.getMessage());
-        }
+        trip = assertDoesNotThrow(() -> Trip.of(raw), "Creation of Trip from valid list failed");
+        assertNotNull(trip);
+        assertEquals(0, trip.directionID());
 
         /* Test exceptions on invalid data */
-        List<Serializable> invalid = new ArrayList<>(raw);
-        invalid.remove(7);
-        invalid.add(7, "123");
-        try {
-            Trip.of(invalid);
-            fail("Creation of Trip with invalid visitID field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid1 = new ArrayList<>(raw);
+        invalid1.remove(7);
+        invalid1.add(7, "123");
+        assertThrows(
+            IOException.class,
+            () -> Trip.of(invalid1),
+            "Creation of Trip with invalid visitID field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(8);
-        invalid.add(8, 25);
-        try {
-            Trip.of(invalid);
-            fail("Creation of Trip with invalid lineID field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid2 = new ArrayList<>(raw);
+        invalid2.remove(8);
+        invalid2.add(8, 25);
+        assertThrows(
+            IOException.class,
+            () -> Trip.of(invalid2),
+            "Creation of Trip with invalid lineID field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(9);
-        invalid.add(9, 234L);
-        try {
-            Trip.of(invalid);
-            fail("Creation of Trip with invalid line name field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid3 = new ArrayList<>(raw);
+        invalid3.remove(9);
+        invalid3.add(9, 234L);
+        assertThrows(
+            IOException.class,
+            () -> Trip.of(invalid3),
+            "Creation of Trip with invalid lineName field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(10);
-        invalid.add(10, "7");   // Strings are generally OK, but 7 is out of range (#2).
-        try {
-            Trip.of(invalid);
-            fail("Creation of Trip with invalid directionID field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid4 = new ArrayList<>(raw);
+        invalid4.remove(10);
+        invalid4.add(10, "7");   // Strings are generally OK, but 7 is out of range (#2).
+        assertThrows(
+            IOException.class,
+            () -> Trip.of(invalid4),
+            "Creation of Trip with invalid directionID field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(11);
-        invalid.add(11, 987);
-        try {
-            Trip.of(invalid);
-            fail("Creation of Trip with invalid destinationName field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid5 = new ArrayList<>(raw);
+        invalid5.remove(11);
+        invalid5.add(11, 987);
+        assertThrows(
+            IOException.class,
+            () -> Trip.of(invalid5),
+            "Creation of Trip with invalid destinationName field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(12);
-        invalid.add(12, 456.78);
-        try {
-            Trip.of(invalid);
-            fail("Creation of Trip with invalid destinationText field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid6 = new ArrayList<>(raw);
+        invalid6.remove(12);
+        invalid6.add(12, 456.78);
+        assertThrows(
+            IOException.class,
+            () -> Trip.of(invalid6),
+            "Creation of Trip with invalid destinationText field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(13);
-        invalid.add(13, 'x');
-        try {
-            Trip.of(invalid);
-            fail("Creation of Trip with invalid vehicleID field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid7 = new ArrayList<>(raw);
+        invalid7.remove(13);
+        invalid7.add(13, 'x');
+        assertThrows(
+            IOException.class,
+            () -> Trip.of(invalid7),
+            "Creation of Trip with invalid vehicleID field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(14);
-        invalid.add(14, 1.2);
-        try {
-            Trip.of(invalid);
-            fail("Creation of Trip with invalid id field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid8 = new ArrayList<>(raw);
+        invalid8.remove(14);
+        invalid8.add(14, 1.2);
+        assertThrows(
+            IOException.class,
+            () -> Trip.of(invalid8),
+            "Creation of Trip with invalid id field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(15);
-        invalid.add(15, 456);
-        try {
-            Trip.of(invalid);
-            fail("Creation of Trip with invalid estimatedTime field successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid9 = new ArrayList<>(raw);
+        invalid9.remove(15);
+        invalid9.add(15, 456);
+        assertThrows(
+            IOException.class,
+            () -> Trip.of(invalid9),
+            "Creation of Trip with invalid estimatedTime field successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.remove(15);
-        try {
-            Trip.of(invalid);
-            fail("Creation of Trip with too short list successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid10 = new ArrayList<>(raw);
+        invalid10.remove(15);
+        assertThrows(
+            IOException.class,
+            () -> Trip.of(invalid10),
+            "Creation of Trip with too short list successful"
+        );
 
-        invalid = new ArrayList<>(raw);
-        invalid.set(10, 3);
-        try {
-            Trip.of(invalid);
-            fail("Creation of Trip with direction ID 3 successful");
-        } catch (Exception e) {
-            assertThat(e, is(instanceOf(IOException.class)));
-        }
+        var invalid11 = new ArrayList<>(raw);
+        invalid11.set(10, 3);
+        assertThrows(
+            IOException.class,
+            () -> Trip.of(invalid11),
+            "Creation of Trip with direction ID 3 successful"
+        );
     }
 }

--- a/src/test/java/de/stklcode/pubtrans/ura/reader/AsyncUraTripReaderTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/reader/AsyncUraTripReaderTest.java
@@ -39,10 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -60,8 +57,8 @@ class AsyncUraTripReaderTest {
     public static void setUp() {
         // Initialize HTTP mock.
         httpMock = new WireMockServer(WireMockConfiguration.options().dynamicPort()
-                .asynchronousResponseEnabled(true)
-                .extensions(StreamTransformer.class)
+            .asynchronousResponseEnabled(true)
+            .extensions(StreamTransformer.class)
         );
         httpMock.start();
         WireMock.configureFor("localhost", httpMock.port());
@@ -92,13 +89,13 @@ class AsyncUraTripReaderTest {
         readLinesToMock(1, "/__files/stream_V1_stops_all.txt", 8);
 
         AsyncUraTripReader tr = new AsyncUraTripReader(
-                URI.create(httpMock.baseUrl() + "/interfaces/ura/stream_V1"),
-                Collections.singletonList(
-                        trip -> {
-                            trips.add(trip);
-                            counter.incrementAndGet();
-                        }
-                )
+            URI.create(httpMock.baseUrl() + "/interfaces/ura/stream_V1"),
+            Collections.singletonList(
+                trip -> {
+                    trips.add(trip);
+                    counter.incrementAndGet();
+                }
+            )
         );
 
         // Open the reader.
@@ -110,20 +107,20 @@ class AsyncUraTripReaderTest {
         // Wait another 1s for the callback to be triggered.
         TimeUnit.SECONDS.sleep(1);
 
-        assertThat("Unexpected number of trips after first entry", trips.size(), is(2));
+        assertEquals(2, trips.size(), "Unexpected number of trips after first entry");
 
         // Flush all remaining lines.
         TimeUnit.SECONDS.sleep(3);
 
-        assertThat("Unexpected number of trips after all lines have been flushed", trips.size(), is(7));
+        assertEquals(7, trips.size(), "Unexpected number of trips after all lines have been flushed");
 
         // Clear trip list and repeat with V2 data.
         trips.clear();
         readLinesToMock(2, "/__files/stream_V2_stops_all.txt", 8);
 
         tr = new AsyncUraTripReader(
-                URI.create(httpMock.baseUrl() + "/interfaces/ura/stream_V2"),
-                trips::add
+            URI.create(httpMock.baseUrl() + "/interfaces/ura/stream_V2"),
+            trips::add
         );
 
         // Open the reader.
@@ -133,7 +130,7 @@ class AsyncUraTripReaderTest {
         assumeTrue(trips.isEmpty(), "Trips should empty after 1s without reading");
 
         TimeUnit.SECONDS.sleep(1);
-        assertThat("Unexpected number of v2 trips after first entry", trips.size(), is(2));
+        assertEquals(2, trips.size(), "Unexpected number of v2 trips after first entry");
 
         // Add a second consumer that pushes to another list.
         Deque<Trip> trips2 = new ConcurrentLinkedDeque<>();
@@ -144,9 +141,9 @@ class AsyncUraTripReaderTest {
 
         tr.close();
 
-        assertThat("Unexpected number of v2 trips after all lines have been flushed", trips.size(), is(7));
-        assertThat("Unexpected number of v2 trips in list 2 after all lines have been flushed", trips2.size(), is(5));
-        assertThat("Same object should have been pushed to both lists", trips.containsAll(trips2));
+        assertEquals(7, trips.size(), "Unexpected number of v2 trips after all lines have been flushed");
+        assertEquals(5, trips2.size(), "Unexpected number of v2 trips in list 2 after all lines have been flushed");
+        assertTrue(trips.containsAll(trips2), "Same object should have been pushed to both lists");
 
         // Opening the reader twice should raise an exception.
         assertDoesNotThrow(tr::open, "Opening the reader after closing should not fail");
@@ -171,13 +168,13 @@ class AsyncUraTripReaderTest {
         readLinesToMock(1, "/__files/stream_V1_stops_all.txt", 8);
 
         AsyncUraTripReader tr = new AsyncUraTripReader(
-                URI.create(httpMock.baseUrl() + "/interfaces/ura/stream_V1"),
-                Collections.singletonList(
-                        trip -> {
-                            trips.add(trip);
-                            counter.incrementAndGet();
-                        }
-                )
+            URI.create(httpMock.baseUrl() + "/interfaces/ura/stream_V1"),
+            Collections.singletonList(
+                trip -> {
+                    trips.add(trip);
+                    counter.incrementAndGet();
+                }
+            )
         );
 
         // Open the reader.
@@ -197,7 +194,7 @@ class AsyncUraTripReaderTest {
 
         // Wait for another second.
         TimeUnit.MILLISECONDS.sleep(1);
-        assertThat("Unexpected number of trips after all lines have been flushed", trips.size(), is(1));
+        assertEquals(1, trips.size(), "Unexpected number of trips after all lines have been flushed");
     }
 
     @Test
@@ -212,16 +209,16 @@ class AsyncUraTripReaderTest {
         readLinesToMock(1, "/__files/stream_V1_stops_all.txt", 8);
 
         AsyncUraTripReader tr = new AsyncUraTripReader(
-                URI.create(httpMock.baseUrl() + "/interfaces/ura/stream_V1"),
-                UraClientConfiguration.forBaseURL(httpMock.baseUrl())
-                        .withConnectTimeout(Duration.ofMillis(100))
-                        .build(),
-                Collections.singletonList(
-                        trip -> {
-                            trips.add(trip);
-                            counter.incrementAndGet();
-                        }
-                )
+            URI.create(httpMock.baseUrl() + "/interfaces/ura/stream_V1"),
+            UraClientConfiguration.forBaseURL(httpMock.baseUrl())
+                .withConnectTimeout(Duration.ofMillis(100))
+                .build(),
+            Collections.singletonList(
+                trip -> {
+                    trips.add(trip);
+                    counter.incrementAndGet();
+                }
+            )
         );
 
         // Open the reader.
@@ -233,20 +230,20 @@ class AsyncUraTripReaderTest {
         // Wait another 1s for the callback to be triggered.
         TimeUnit.SECONDS.sleep(1);
 
-        assertThat("Unexpected number of trips after first entry", trips.size(), is(2));
+        assertEquals(2, trips.size(), "Unexpected number of trips after first entry");
 
         // Flush all remaining lines.
         TimeUnit.SECONDS.sleep(3);
 
-        assertThat("Unexpected number of trips after all lines have been flushed", trips.size(), is(7));
+        assertEquals(7, trips.size(), "Unexpected number of trips after all lines have been flushed");
 
         // Clear trip list and repeat with V2 data.
         trips.clear();
         readLinesToMock(2, "/__files/stream_V2_stops_all.txt", 8);
 
         tr = new AsyncUraTripReader(
-                URI.create(httpMock.baseUrl() + "/interfaces/ura/stream_V2"),
-                Collections.singletonList(trips::add)
+            URI.create(httpMock.baseUrl() + "/interfaces/ura/stream_V2"),
+            Collections.singletonList(trips::add)
         );
 
         // Open the reader.
@@ -256,7 +253,7 @@ class AsyncUraTripReaderTest {
         assumeTrue(trips.isEmpty(), "Trips should empty after 1s without reading");
 
         TimeUnit.SECONDS.sleep(1);
-        assertThat("Unexpected number of v2 trips after first entry", trips.size(), is(2));
+        assertEquals(2, trips.size(), "Unexpected number of v2 trips after first entry");
 
         // Add a second consumer that pushes to another list.
         Deque<Trip> trips2 = new ConcurrentLinkedDeque<>();
@@ -267,9 +264,9 @@ class AsyncUraTripReaderTest {
 
         tr.close();
 
-        assertThat("Unexpected number of v2 trips after all lines have been flushed", trips.size(), is(7));
-        assertThat("Unexpected number of v2 trips in list 2 after all lines have been flushed", trips2.size(), is(5));
-        assertThat("Same object should have been pushed to both lists", trips.containsAll(trips2));
+        assertEquals(7, trips.size(), "Unexpected number of v2 trips after all lines have been flushed");
+        assertEquals(5, trips2.size(), "Unexpected number of v2 trips in list 2 after all lines have been flushed");
+        assertTrue(trips.containsAll(trips2), "Same object should have been pushed to both lists");
     }
 
     /**
@@ -281,10 +278,10 @@ class AsyncUraTripReaderTest {
      */
     private void readLinesToMock(int version, String resourceFile, int chunks) {
         WireMock.stubFor(get(urlPathEqualTo("/interfaces/ura/stream_V" + version))
-                .willReturn(aResponse()
-                        .withTransformer("stream-transformer", "source", resourceFile)
-                        .withTransformer("stream-transformer", "chunks", chunks)
-                )
+            .willReturn(aResponse()
+                .withTransformer("stream-transformer", "source", resourceFile)
+                .withTransformer("stream-transformer", "chunks", chunks)
+            )
         );
     }
 
@@ -294,11 +291,11 @@ class AsyncUraTripReaderTest {
             Parameters parameters = serveEvent.getTransformerParameters();
             int chunks = parameters.getInt("chunks", 1);
             return Response.Builder.like(response)
-                    // Read source file to response.
-                    .body(() -> AsyncUraTripReaderTest.class.getResourceAsStream(parameters.getString("source")))
-                    // Split response in given number of chunks with 500ms delay.
-                    .chunkedDribbleDelay(new ChunkedDribbleDelay(chunks, chunks * 500))
-                    .build();
+                // Read source file to response.
+                .body(() -> AsyncUraTripReaderTest.class.getResourceAsStream(parameters.getString("source")))
+                // Split response in given number of chunks with 500ms delay.
+                .chunkedDribbleDelay(new ChunkedDribbleDelay(chunks, chunks * 500))
+                .build();
         }
 
         @Override


### PR DESCRIPTION
We do not use any complex assertions, so let's simplify the stack and use basic JUnit Jupiter assertions.