### PR TITLE
fix: throw exception API requests return HTTP status != 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 * Updated Jackson dependency to 3.1.3 (#93)
 * Use Java _record_ classes for `Message`, `Stop` and `Trip` models (#94)
 
+### Fixed
+* Throw exception on HTTP status != 200 instead of silently returning no results (#96)
+
 
 ## 2.0.11 - 2026-05-14
 

--- a/src/main/java/de/stklcode/pubtrans/ura/UraClient.java
+++ b/src/main/java/de/stklcode/pubtrans/ura/UraClient.java
@@ -508,7 +508,11 @@ public class UraClient implements Serializable {
                 reqBuilder.timeout(config.timeout());
             }
 
-            return clientBuilder.build().send(reqBuilder.build(), HttpResponse.BodyHandlers.ofInputStream()).body();
+            var response = clientBuilder.build().send(reqBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() != 200) {
+                throw new IOException("API request failed with status " + response.statusCode());
+            }
+            return response.body();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException("API request interrupted", e);

--- a/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
@@ -65,14 +65,13 @@ class UraClientTest {
         assertEquals(6.0708663, stops.get(4).longitude());
 
         // Test Exception handling.
-        /*
         mockHttpToError(500);
 
         var uraClient = new UraClient(wireMock.baseUrl());
-        var e = assertThrows(IllegalStateException.class, uraClient::getStops);
-        assertInstanceOf(IOException.class, e.getCause());
-        assertTrue(e.getCause().getMessage().startsWith("Server returned HTTP response code: 500 for URL"));
-        */
+        Exception e = assertThrows(UraClientException.class, uraClient::getStops);
+        assertEquals("Failed to read stops from API", e.getMessage());
+        e = assertInstanceOf(IOException.class, e.getCause());
+        assertEquals("API request failed with status 500", e.getMessage());
     }
 
     @Test
@@ -203,21 +202,23 @@ class UraClientTest {
         assertEquals(5, trips.size());
 
         // Test Exception handling.
-        /*
         mockHttpToError(502);
         var uraClient = new UraClient(wireMock.baseUrl());
-        var e = assertThrows(IllegalStateException.class, uraClient::getTrips);
-        assertInstanceOf(IOException.class, e.getCause());
-        assertTrue(e.getCause().getMessage().startsWith("Server returned HTTP response code: 502 for URL"));
-        */
+        Exception e = assertThrows(UraClientException.class, uraClient::getStops);
+        assertEquals("Failed to read stops from API", e.getMessage());
+        e = assertInstanceOf(IOException.class, e.getCause());
+        assertEquals("API request failed with status 502", e.getMessage());
+
         mockHttpToException();
-        UraClientException exception = assertThrows(
+        e = assertThrows(
             UraClientException.class,
             () -> new UraClient(wireMock.baseUrl()).getTrips(),
             "Expected reader to raise an exception"
         );
-        assertEquals("Failed to read trips from API", exception.getMessage(), "Unexpected error message");
-        assertInstanceOf(IOException.class, exception.getCause(), "Unexpected error cause");
+        assertEquals("Failed to read trips from API", e.getMessage(), "Unexpected error message");
+        assertInstanceOf(IOException.class, e.getCause(), "Unexpected error cause");
+        assertEquals("Failed to read trips from API", e.getMessage(), "Unexpected error message");
+        assertInstanceOf(IOException.class, e.getCause(), "Unexpected error cause");
 
     }
 


### PR DESCRIPTION
This is an old regression from Java 11 HttpClient migration that was never properly tested. Empty responses with HTTP error status silently fail with an empty list of stops/trips.
Validate response status and throw an exception if it's not 200.

Fixes: 88c10d53332e0146e69dbbcfa5084f6bdefb0ed3