### PR TITLE
[2.x] fix: throw exception API requests return HTTP status != 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2.0.12 - unreleased
+
+### Fixed
+* Throw exception on HTTP status != 200 instead of silently returning no results (#97)
+
+
 ## 2.0.11 - 2026-05-14
 
 ### Dependencies

--- a/src/main/java/de/stklcode/pubtrans/ura/UraClient.java
+++ b/src/main/java/de/stklcode/pubtrans/ura/UraClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Stefan Kalscheuer
+ * Copyright 2016-2026 Stefan Kalscheuer
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -505,7 +505,11 @@ public class UraClient implements Serializable {
                 reqBuilder.timeout(config.getTimeout());
             }
 
-            return clientBuilder.build().send(reqBuilder.build(), HttpResponse.BodyHandlers.ofInputStream()).body();
+            var response = clientBuilder.build().send(reqBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() != 200) {
+                throw new IOException("API request failed with status " + response.statusCode());
+            }
+            return response.body();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException("API request interrupted", e);

--- a/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
+++ b/src/test/java/de/stklcode/pubtrans/ura/UraClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 Stefan Kalscheuer
+ * Copyright 2016-2026 Stefan Kalscheuer
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,12 +35,13 @@ import java.util.Optional;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.startsWith;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit test for the URA Client.
@@ -73,13 +74,10 @@ class UraClientTest {
         // Test Exception handling.
         mockHttpToError(500);
 
-        try {
-            new UraClient(wireMock.baseUrl()).getStops();
-        } catch (RuntimeException e) {
-            assertThat(e, is(instanceOf(IllegalStateException.class)));
-            assertThat(e.getCause(), is(instanceOf(IOException.class)));
-            assertThat(e.getCause().getMessage(), startsWith("Server returned HTTP response code: 500 for URL"));
-        }
+        var uraClient = new UraClient(wireMock.baseUrl());
+        var e = assertThrows(UraClientException.class, uraClient::getStops);
+        assertThat(e.getCause(), is(instanceOf(IOException.class)));
+        assertThat(e.getCause().getMessage(), is("API request failed with status 500"));
     }
 
     @Test
@@ -212,18 +210,15 @@ class UraClientTest {
         trips = new UraClient(wireMock.baseUrl()).getTrips(5);
         assertThat(trips, hasSize(5));
 
-        // Test mockException handling.
+        // Test Exception handling.
+        var uraClient = new UraClient(wireMock.baseUrl());
         mockHttpToError(502);
-        try {
-            new UraClient(wireMock.baseUrl()).getTrips();
-        } catch (RuntimeException e) {
-            assertThat(e, is(instanceOf(IllegalStateException.class)));
-            assertThat(e.getCause(), is(instanceOf(IOException.class)));
-            assertThat(e.getCause().getMessage(), startsWith("Server returned HTTP response code: 502 for URL"));
-        }
+        var exception = assertThrows(UraClientException.class, uraClient::getTrips);
+        assertThat(exception.getCause(), is(instanceOf(IOException.class)));
+        assertThat(exception.getCause().getMessage(), is("API request failed with status 502"));
 
         mockHttpToException();
-        UraClientException exception = assertThrows(
+        exception = assertThrows(
                 UraClientException.class,
                 () -> new UraClient(wireMock.baseUrl()).getTrips(),
                 "Expected reader to raise an exception"


### PR DESCRIPTION
This is an old regression from Java 11 HttpClient migration that was never properly tested. Empty responses with HTTP error status silently fail with an empty list of stops/trips.
Validate response status and throw an exception if it's not 200.

Fixes: 88c10d53332e0146e69dbbcfa5084f6bdefb0ed3

(cherry picked from commit f37b73cafdbfb9087643435c29527ce88e405225)